### PR TITLE
Add support for resources and fields with dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Support for accessing the resource with fields
+- Support for using fields to select keys that contain dots
+
 ## [0.9.12] - 2020-08-25
 ### Changed
 - Agent is now embeddable with a default output

--- a/docs/types/field.md
+++ b/docs/types/field.md
@@ -3,7 +3,9 @@
 _Fields_ are the primary way to tell stanza which values of an entry to use in its operators.
 Most often, these will be things like fields to parse for a parser operator, or the field to write a new value to.
 
-Fields are `.`-delimited strings which allow you to select labels or records on the entry. Fields can currently be used to select labels or values on a record. To select a label, prefix your field with `$label.` such as with `$label.my_label`. For values on the record, use the prefix `$record.` such as `$record.my_value`.
+Fields are `.`-delimited strings which allow you to select labels or records on the entry. Fields can currently be used to select labels, values on a record, or resource values. To select a label, prefix your field with `$label` such as with `$label.my_label`. For values on the record, use the prefix `$record` such as `$record.my_value`. For resource values, use the prefix `$resource`.
+
+If a key contains a dot in it, a field can alternatively use bracket syntax for traversing through a map. For example, to select the key `k8s.cluster.name` on the entry's record, you can use the field `$record["k8s.cluster.name"]`.
 
 Record fields can be nested arbitrarily deeply, such as `$record.my_value.my_nested_value`.
 

--- a/entry/field.go
+++ b/entry/field.go
@@ -3,7 +3,6 @@ package entry
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 )
 
 // Field represents a potential field on an entry.
@@ -44,7 +43,10 @@ func (f *Field) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func fieldFromString(s string) (Field, error) {
-	split := strings.Split(s, ".")
+	split, err := splitField(s)
+	if err != nil {
+		return Field{}, fmt.Errorf("splitting field: %s", err)
+	}
 
 	switch split[0] {
 	case "$labels":
@@ -67,4 +69,84 @@ func (f Field) MarshalJSON() ([]byte, error) {
 // MarshalYAML will marshal a field into YAML
 func (f Field) MarshalYAML() (interface{}, error) {
 	return f.String(), nil
+}
+
+type splitState uint
+
+const (
+	BEGIN splitState = iota
+	IN_BRACKET
+	IN_QUOTE
+	OUT_QUOTE
+	OUT_BRACKET
+	IN_UNBRACKETED_TOKEN
+)
+
+func splitField(s string) ([]string, error) {
+	fields := make([]string, 0, 1)
+
+	state := BEGIN
+	var quoteChar rune
+	var tokenStart int
+
+	for i, c := range s {
+		switch state {
+		case BEGIN:
+			if c == '[' {
+				state = IN_BRACKET
+				continue
+			}
+			tokenStart = i
+			state = IN_UNBRACKETED_TOKEN
+		case IN_BRACKET:
+			if !(c == '\'' || c == '"') {
+				return nil, fmt.Errorf("strings in brackets must be surrounded by quotes")
+			}
+			state = IN_QUOTE
+			quoteChar = c
+			tokenStart = i + 1
+		case IN_QUOTE:
+			if c == quoteChar {
+				fields = append(fields, s[tokenStart:i])
+				state = OUT_QUOTE
+			}
+		case OUT_QUOTE:
+			if c != ']' {
+				return nil, fmt.Errorf("found characters between closed quote and closing bracket")
+			}
+			state = OUT_BRACKET
+		case OUT_BRACKET:
+			if c == '.' {
+				state = IN_UNBRACKETED_TOKEN
+				tokenStart = i + 1
+			} else if c == '[' {
+				state = IN_BRACKET
+			} else {
+				return nil, fmt.Errorf("bracketed access must be followed by a dot or another bracketed access")
+			}
+		case IN_UNBRACKETED_TOKEN:
+			if c == '.' {
+				fields = append(fields, s[tokenStart:i])
+				tokenStart = i + 1
+			} else if c == '[' {
+				fields = append(fields, s[tokenStart:i])
+				state = IN_BRACKET
+			}
+		}
+	}
+
+	switch state {
+	case IN_BRACKET, OUT_QUOTE:
+		return nil, fmt.Errorf("found unclosed left bracket")
+	case IN_QUOTE:
+		if quoteChar == '"' {
+			return nil, fmt.Errorf("found unclosed double quote")
+		} else {
+			return nil, fmt.Errorf("found unclosed single quote")
+		}
+	case IN_UNBRACKETED_TOKEN:
+		fields = append(fields, s[tokenStart:])
+	}
+
+	return fields, nil
 }

--- a/entry/field.go
+++ b/entry/field.go
@@ -54,6 +54,11 @@ func fieldFromString(s string) (Field, error) {
 			return Field{}, fmt.Errorf("labels cannot be nested")
 		}
 		return Field{LabelField{split[1]}}, nil
+	case "$resource":
+		if len(split) != 2 {
+			return Field{}, fmt.Errorf("resource fields cannot be nested")
+		}
+		return Field{ResourceField{split[1]}}, nil
 	case "$record", "$":
 		return Field{RecordField{split[1:]}}, nil
 	default:

--- a/entry/resource_field.go
+++ b/entry/resource_field.go
@@ -1,0 +1,51 @@
+package entry
+
+import "fmt"
+
+// ResourceField is the path to an entry's resource key
+type ResourceField struct {
+	key string
+}
+
+// Get will return the resource value and a boolean indicating if it exists
+func (l ResourceField) Get(entry *Entry) (interface{}, bool) {
+	if entry.Resource == nil {
+		return "", false
+	}
+	val, ok := entry.Resource[l.key]
+	return val, ok
+}
+
+// Set will set the resource value on an entry
+func (l ResourceField) Set(entry *Entry, val interface{}) error {
+	if entry.Resource == nil {
+		entry.Resource = make(map[string]string, 1)
+	}
+
+	str, ok := val.(string)
+	if !ok {
+		return fmt.Errorf("cannot set a resource to a non-string value")
+	}
+	entry.Resource[l.key] = str
+	return nil
+}
+
+// Delete will delete a resource key from an entry
+func (l ResourceField) Delete(entry *Entry) (interface{}, bool) {
+	if entry.Resource == nil {
+		return "", false
+	}
+
+	val, ok := entry.Resource[l.key]
+	delete(entry.Resource, l.key)
+	return val, ok
+}
+
+func (l ResourceField) String() string {
+	return "$resource." + l.key
+}
+
+// NewResourceField will creat a new resource field from a key
+func NewResourceField(key string) Field {
+	return Field{ResourceField{key}}
+}

--- a/entry/resource_field_test.go
+++ b/entry/resource_field_test.go
@@ -1,0 +1,202 @@
+package entry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceFieldGet(t *testing.T) {
+	cases := []struct {
+		name       string
+		resources  map[string]string
+		field      Field
+		expected   interface{}
+		expectedOK bool
+	}{
+		{
+			"Simple",
+			map[string]string{
+				"test": "val",
+			},
+			NewResourceField("test"),
+			"val",
+			true,
+		},
+		{
+			"NonexistentKey",
+			map[string]string{
+				"test": "val",
+			},
+			NewResourceField("nonexistent"),
+			"",
+			false,
+		},
+		{
+			"NilMap",
+			nil,
+			NewResourceField("nonexistent"),
+			"",
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := New()
+			entry.Resource = tc.resources
+			val, ok := entry.Get(tc.field)
+			require.Equal(t, tc.expectedOK, ok)
+			require.Equal(t, tc.expected, val)
+		})
+	}
+
+}
+
+func TestResourceFieldDelete(t *testing.T) {
+	cases := []struct {
+		name              string
+		resources         map[string]string
+		field             Field
+		expected          interface{}
+		expectedOK        bool
+		expectedResources map[string]string
+	}{
+		{
+			"Simple",
+			map[string]string{
+				"test": "val",
+			},
+			NewResourceField("test"),
+			"val",
+			true,
+			map[string]string{},
+		},
+		{
+			"NonexistentKey",
+			map[string]string{
+				"test": "val",
+			},
+			NewResourceField("nonexistent"),
+			"",
+			false,
+			map[string]string{
+				"test": "val",
+			},
+		},
+		{
+			"NilMap",
+			nil,
+			NewResourceField("nonexistent"),
+			"",
+			false,
+			nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := New()
+			entry.Resource = tc.resources
+			val, ok := entry.Delete(tc.field)
+			require.Equal(t, tc.expectedOK, ok)
+			require.Equal(t, tc.expected, val)
+		})
+	}
+
+}
+
+func TestResourceFieldSet(t *testing.T) {
+	cases := []struct {
+		name        string
+		resources   map[string]string
+		field       Field
+		val         interface{}
+		expected    map[string]string
+		expectedErr bool
+	}{
+		{
+			"Simple",
+			map[string]string{},
+			NewResourceField("test"),
+			"val",
+			map[string]string{
+				"test": "val",
+			},
+			false,
+		},
+		{
+			"Overwrite",
+			map[string]string{
+				"test": "original",
+			},
+			NewResourceField("test"),
+			"val",
+			map[string]string{
+				"test": "val",
+			},
+			false,
+		},
+		{
+			"NilMap",
+			nil,
+			NewResourceField("test"),
+			"val",
+			map[string]string{
+				"test": "val",
+			},
+			false,
+		},
+		{
+			"NonString",
+			map[string]string{},
+			NewResourceField("test"),
+			123,
+			map[string]string{
+				"test": "val",
+			},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := New()
+			entry.Resource = tc.resources
+			err := entry.Set(tc.field, tc.val)
+			if tc.expectedErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.Equal(t, tc.expected, entry.Resource)
+		})
+	}
+
+}
+
+func TestResourceFieldString(t *testing.T) {
+	cases := []struct {
+		name     string
+		field    ResourceField
+		expected string
+	}{
+		{
+			"Simple",
+			ResourceField{"foo"},
+			"$resource.foo",
+		},
+		{
+			"Empty",
+			ResourceField{""},
+			"$resource.",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.field.String())
+		})
+	}
+
+}

--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,7 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kyoh86/exportloopref v0.1.7 h1:u+iHuTbkbTS2D/JP7fCuZDo/t3rBVGo3Hf58Rc+lQVY=
 github.com/kyoh86/exportloopref v0.1.7/go.mod h1:h1rDl2Kdj97+Kwh4gdz3ujE7XHmH51Q0lUiZ1z4NLj8=
@@ -358,6 +359,7 @@ github.com/nakabonne/nestif v0.3.0 h1:+yOViDGhg8ygGrmII72nV9B/zGxY188TYpfolntsaP
 github.com/nakabonne/nestif v0.3.0/go.mod h1:dI314BppzXjJ4HsCnbo7XzrJHPszZsjnk5wEBSYHI2c=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1ORQBMvzfzBgpsctsbQikCVpvC+tX285E=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.0.0-20200708172631-8866003e3856 h1:W3KBC2LFyfgd+wNudlfgCCsTo4q97MeNWrfz8/wSdSc=
 github.com/nishanths/exhaustive v0.0.0-20200708172631-8866003e3856/go.mod h1:wBEpHwM2OdmeNpdCvRPUlkEbBuaFmcK4Wv8Q7FuGW3c=
@@ -751,6 +753,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=


### PR DESCRIPTION
## Description of Changes

- Adds support for accessing the entry's resource with fields
- Adds support for accessing fields with dots in their keys. For example `$resource["k8s.cluster.name"]`

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
