### PR TITLE
Remove network mask from decorated IP

### DIFF
--- a/operator/helper/host_identifier.go
+++ b/operator/helper/host_identifier.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 
 	"github.com/observiq/stanza/entry"
 	"github.com/observiq/stanza/errors"
@@ -91,7 +92,7 @@ func getIP() (string, error) {
 			continue
 		}
 		if len(addrs) > 0 {
-			ip = addrs[0].String()
+			ip = strings.Split(addrs[0].String(), "/")[0]
 		}
 	}
 


### PR DESCRIPTION
## Description of Changes

IPs were previously coming through in the form `192.168.1.1/24`, which causes issues down the line. This splits on the slash, returning only the IP portion. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
