### PR TITLE
Updated k8s_event to support polling for new namespaces

### DIFF
--- a/docs/operators/k8s_event_input.md
+++ b/docs/operators/k8s_event_input.md
@@ -5,14 +5,16 @@ Kubernetes API, and currently requires that Stanza is running inside a Kubernete
 
 ### Configuration Fields
 
-| Field        | Default           | Description                                                                                      |
-| ---          | ---               | ---                                                                                              |
-| `id`         | `k8s_event_input` | A unique identifier for the operator                                                             |
-| `output`     | Next in pipeline  | The connected operator(s) that will receive all outbound entries                                 |
-| `namespaces` | All namespaces    | An array of namespaces to collect events from. If unset, defaults to all namespaces.             |
-| `write_to`   | $                 | The record [field](/docs/types/field.md) written to when creating a new log entry                |
-| `labels`     | {}                | A map of `key: value` labels to add to the entry's labels                                        |
-| `resource`   | {}                | A map of `key: value` labels to add to the entry's resource                                      |
+| Field                 | Default           | Description                                                                                      |
+| ---                   | ---               | ---                                                                                              |
+| `id`                  | `k8s_event_input` | A unique identifier for the operator                                                             |
+| `output`              | Next in pipeline  | The connected operator(s) that will receive all outbound entries                                 |
+| `namespaces`          | All namespaces    | An array of namespaces to collect events from.                                                   |
+| `discover_namespaces` | `false`           | If true, the operator will regularly poll for new namespaces to include                          |
+| `discovery_interval ` | `1m`              | The interval at which the operator searches for new namespaces to follow                         |
+| `write_to`            | $                 | The record [field](/docs/types/field.md) written to when creating a new log entry                |
+| `labels`              | {}                | A map of `key: value` labels to add to the entry's labels                                        |
+| `resource`            | {}                | A map of `key: value` labels to add to the entry's resource                                      |
  
 ### Example Configurations
 

--- a/docs/operators/k8s_event_input.md
+++ b/docs/operators/k8s_event_input.md
@@ -10,7 +10,7 @@ Kubernetes API, and currently requires that Stanza is running inside a Kubernete
 | `id`                  | `k8s_event_input` | A unique identifier for the operator                                                             |
 | `output`              | Next in pipeline  | The connected operator(s) that will receive all outbound entries                                 |
 | `namespaces`          | All namespaces    | An array of namespaces to collect events from.                                                   |
-| `discover_namespaces` | `false`           | If true, the operator will regularly poll for new namespaces to include                          |
+| `discover_namespaces` | `true`            | If true, the operator will regularly poll for new namespaces to include                          |
 | `discovery_interval ` | `1m`              | The interval at which the operator searches for new namespaces to follow                         |
 | `write_to`            | $                 | The record [field](/docs/types/field.md) written to when creating a new log entry                |
 | `labels`              | {}                | A map of `key: value` labels to add to the entry's labels                                        |

--- a/operator/builtin/input/k8sevent/k8s_event.go
+++ b/operator/builtin/input/k8sevent/k8s_event.go
@@ -99,7 +99,12 @@ func (k *K8sEvents) Start() error {
 		if err != nil {
 			return errors.Wrap(err, "initial namespace discovery")
 		}
-		k.namespaces = append(k.namespaces, namespaces...)
+
+		for _, namespace := range namespaces {
+			if !k.hasNamespace(namespace) {
+				k.namespaces = append(k.namespaces, namespace)
+			}
+		}
 	}
 
 	// Test connection

--- a/operator/builtin/input/k8sevent/k8s_event.go
+++ b/operator/builtin/input/k8sevent/k8s_event.go
@@ -29,7 +29,7 @@ func NewK8sEventsConfig(operatorID string) *K8sEventsConfig {
 	return &K8sEventsConfig{
 		InputConfig:        helper.NewInputConfig(operatorID, "k8s_event_input"),
 		Namespaces:         []string{},
-		DiscoverNamespaces: false,
+		DiscoverNamespaces: true,
 		DiscoveryInterval:  helper.Duration{Duration: time.Minute * 1},
 	}
 }
@@ -39,7 +39,7 @@ type K8sEventsConfig struct {
 	helper.InputConfig `yaml:",inline"`
 	Namespaces         []string        `json:"namespaces" yaml:"namespaces"`
 	DiscoverNamespaces bool            `json:"discover_namespaces" yaml:"discover_namespaces"`
-	DiscoveryInterval  helper.Duration `json:"discovery_interval yaml:"discovery_interval"`
+	DiscoveryInterval  helper.Duration `json:"discovery_interval" yaml:"discovery_interval"`
 }
 
 // Build will build a k8s_event_input operator from the supplied configuration


### PR DESCRIPTION
## Description of Changes
- Adds a namespace discovery mode and polling interval
- Removes logic that put the operator in discovery mode only when namespaces were not specified
- Returns an error if namespaces are not specified and discovery mode is set to false
- Supports specifying namespaces and discovering namespaces at the same time
- Removed test connection logic. 
  - Explanation: it didn't make sense to throw an error at build time, when the operator could be configured in discovery mode and not throw an error, even if the namespace fails. Also, the previous test connection logic only tested the first item in the list.
- Updated documentation

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
