### PR TITLE
Add make vet task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,12 @@ listmod:
 lint:
 	golangci-lint run ./...
 
+.PHONY: vet
+vet:
+	GOOS=darwin $(MAKE) for-all CMD="go vet ./..."
+	GOOS=linux $(MAKE) for-all CMD="go vet ./..."
+	GOOS=windows $(MAKE) for-all CMD="go vet ./..."
+
 .PHONY: generate
 generate:
 	go generate ./...

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,10 @@ install-tools:
 	go install github.com/vektra/mockery/cmd/mockery
 
 .PHONY: test
-test:
+test: vet test-only
+
+.PHONY: test-only
+test-only:
 	$(MAKE) for-all CMD="go test -race -coverprofile coverage.txt -coverpkg ./... ./..."
 
 .PHONY: bench

--- a/cmd/stanza/go.sum
+++ b/cmd/stanza/go.sum
@@ -255,6 +255,7 @@ github.com/observiq/go-syslog/v3 v3.0.2 h1:vaeINFErM/E3cKE2Ot1FAhhGq5mv7uGBOzjnG
 github.com/observiq/go-syslog/v3 v3.0.2/go.mod h1:9abcumkQwDUY0VgWdH6CaaJ3Ks39A7NvIelMlavPru0=
 github.com/observiq/nanojack v0.0.0-20200910202758-a0af1c611319 h1:33Fh2cXMUKlnSxYAqt9+BHZRdK01/P6lJNfXttwmIjk=
 github.com/observiq/nanojack v0.0.0-20200910202758-a0af1c611319/go.mod h1:f+QQxL9zFpO5q44o7rf+TOEtEmlMQUI9snW9ZADIku0=
+github.com/observiq/nanojack v2.0.0+incompatible/go.mod h1:i16Ycy0qfRu50OKvir9uV045s9oqLzOK16sFqjS6/d0=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/operator/builtin/input/file/file_test.go
+++ b/operator/builtin/input/file/file_test.go
@@ -735,7 +735,7 @@ func (rt rotationTest) run(tc rotationTest, copyTruncate bool) func(t *testing.T
 	return func(t *testing.T) {
 		operator, logReceived, tempDir := newTestFileOperator(t,
 			func(cfg *InputConfig) {
-				cfg.PollInterval = helper.Duration{tc.pollInterval}
+				cfg.PollInterval = helper.NewDuration(tc.pollInterval)
 			},
 			func(out *testutil.FakeOutput) {
 				out.Received = make(chan *entry.Entry, tc.totalLines)


### PR DESCRIPTION
## Description of Changes

Adds a `make vet` task, which runs `go vet` on each module, for each supported OS. 

On my machine, fresh run takes about 1 minute, and a re-run takes about 25 seconds. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
