### PR TITLE
Add Makefile task to check for missing modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,20 @@ lint:
 	golangci-lint run ./...
 
 .PHONY: vet
-vet:
+vet: check-missing-modules
 	GOOS=darwin $(MAKE) for-all CMD="go vet ./..."
 	GOOS=linux $(MAKE) for-all CMD="go vet ./..."
 	GOOS=windows $(MAKE) for-all CMD="go vet ./..."
+
+.PHONY: check-missing-modules
+check-missing-modules:
+	@find ./operator/builtin -type f -name "go.mod" -exec dirname {} \; | cut -d'/' -f2- | while read mod ; do \
+		grep $$mod ./cmd/stanza/init_*.go > /dev/null ;\
+		if [ $$? -ne 0 ] ; then \
+			echo Stanza is not building with module $$mod ;\
+			exit 1 ;\
+		fi \
+	done
 
 .PHONY: generate
 generate:


### PR DESCRIPTION
## Description of Changes

Adds a Makefile task that fails if any of the builtin operator modules are not included in the `init_*` files for the standalone binary build. Adds the test as a dependency on `make vet`

```
❯ make vet
Stanza is not building with module operator/builtin/input/file
make: *** [check-missing-modules] Error 1
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
