### PR TITLE
Standardize usage of sync.WaitGroup

### DIFF
--- a/operator/builtin/input/generate/generate.go
+++ b/operator/builtin/input/generate/generate.go
@@ -54,15 +54,14 @@ type GenerateInput struct {
 	entry  entry.Entry
 	count  int
 	static bool
+	wg     sync.WaitGroup
 	cancel context.CancelFunc
-	wg     *sync.WaitGroup
 }
 
 // Start will start generating log entries.
 func (g *GenerateInput) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	g.cancel = cancel
-	g.wg = &sync.WaitGroup{}
 
 	g.wg.Add(1)
 	go func() {

--- a/operator/builtin/input/journald/journald.go
+++ b/operator/builtin/input/journald/journald.go
@@ -98,7 +98,7 @@ type JournaldInput struct {
 	persist helper.Persister
 	json    jsoniter.API
 	cancel  context.CancelFunc
-	wg      *sync.WaitGroup
+	wg      sync.WaitGroup
 }
 
 type cmd interface {
@@ -112,7 +112,6 @@ var lastReadCursorKey = "lastReadCursor"
 func (operator *JournaldInput) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	operator.cancel = cancel
-	operator.wg = &sync.WaitGroup{}
 
 	err := operator.persist.Load()
 	if err != nil {

--- a/operator/builtin/input/udp/udp.go
+++ b/operator/builtin/input/udp/udp.go
@@ -61,14 +61,13 @@ type UDPInput struct {
 
 	connection net.PacketConn
 	cancel     context.CancelFunc
-	waitGroup  *sync.WaitGroup
+	wg         sync.WaitGroup
 }
 
 // Start will start listening for messages on a socket.
 func (u *UDPInput) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	u.cancel = cancel
-	u.waitGroup = &sync.WaitGroup{}
 
 	conn, err := net.ListenUDP("udp", u.address)
 	if err != nil {
@@ -82,10 +81,10 @@ func (u *UDPInput) Start() error {
 
 // goHandleMessages will handle messages from a udp connection.
 func (u *UDPInput) goHandleMessages(ctx context.Context) {
-	u.waitGroup.Add(1)
+	u.wg.Add(1)
 
 	go func() {
-		defer u.waitGroup.Done()
+		defer u.wg.Done()
 
 		for {
 			message, err := u.readMessage()
@@ -128,6 +127,6 @@ func (u *UDPInput) readMessage() (string, error) {
 func (u *UDPInput) Stop() error {
 	u.cancel()
 	u.connection.Close()
-	u.waitGroup.Wait()
+	u.wg.Wait()
 	return nil
 }

--- a/operator/builtin/input/windows/operator.go
+++ b/operator/builtin/input/windows/operator.go
@@ -82,14 +82,13 @@ type EventLogInput struct {
 	pollInterval helper.Duration
 	offsets      helper.Persister
 	cancel       context.CancelFunc
-	wg           *sync.WaitGroup
+	wg           sync.WaitGroup
 }
 
 // Start will start reading events from a subscription.
 func (e *EventLogInput) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	e.cancel = cancel
-	e.wg = &sync.WaitGroup{}
 
 	e.bookmark = NewBookmark()
 	offsetXML, err := e.getBookmarkOffset()

--- a/operator/builtin/transformer/ratelimit/rate_limit_test.go
+++ b/operator/builtin/transformer/ratelimit/rate_limit_test.go
@@ -37,7 +37,7 @@ func TestRateLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	wg := &sync.WaitGroup{}
+	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()


### PR DESCRIPTION
## Description of Changes

- Removes unnecessary indirection when embedded on a struct
- Standardizes naming to the ecosystem standard `wg`

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
