### PR TITLE
Stop the journald input cleanly to avoid logging after test completion

### DIFF
--- a/operator/builtin/input/journald/journald_test.go
+++ b/operator/builtin/input/journald/journald_test.go
@@ -52,6 +52,7 @@ func TestInputJournald(t *testing.T) {
 
 	err = journaldInput.Start()
 	require.NoError(t, err)
+	defer journaldInput.Stop()
 
 	expected := map[string]interface{}{
 		"_BOOT_ID":                   "c4fa36de06824d21835c05ff80c54468",


### PR DESCRIPTION
## Description of Changes

Logging after test completion caused a failure in the latest master CI run. This should fix that

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
