### PR TITLE
Fix plugin serialization and export plugin object on config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.3] - 2020-10-07
+### Fixed
+- (De)serialization of JSON for plugin config structs
+
 ## [0.12.2] - 2020-10-06
 ### Added
 - New Relic Logs output operator

--- a/operator/buffer/buffer.go
+++ b/operator/buffer/buffer.go
@@ -65,5 +65,13 @@ func (bc *Config) unmarshal(unmarshal func(interface{}) error) error {
 	}
 }
 
+func (bc Config) MarshalYAML() (interface{}, error) {
+	return bc.Builder, nil
+}
+
+func (bc Config) MarshalJSON() ([]byte, error) {
+	return json.Marshal(bc.Builder)
+}
+
 // FlushFunc is a function that can be called to mark the returned entries as flushed
 type FlushFunc func() error

--- a/plugin/config_test.go
+++ b/plugin/config_test.go
@@ -26,6 +26,7 @@ func TestGetRenderParams(t *testing.T) {
 		"param1": "value1",
 		"param2": "value2",
 		"input":  "$.test",
+		"id":     "test",
 		"output": "[$.out1,$.out2]",
 	}
 	require.Equal(t, expected, params)
@@ -65,7 +66,7 @@ output: stdout
 					OperatorType: "my_plugin",
 				},
 			},
-			plugin: plugin,
+			Plugin: plugin,
 			Parameters: map[string]interface{}{
 				"unused_param": "test_unused",
 			},

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -18,6 +18,7 @@ type Plugin struct {
 	ID          string
 	Version     string
 	Title       string
+	Type        string
 	Description string
 	Parameters  map[string]Parameter
 	Template    *template.Template
@@ -26,7 +27,7 @@ type Plugin struct {
 // NewBuilder creates a new, empty config that can build into an operator
 func (p *Plugin) NewBuilder() operator.MultiBuilder {
 	return &Config{
-		plugin: p,
+		Plugin: p,
 	}
 }
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -18,7 +18,6 @@ type Plugin struct {
 	ID          string
 	Version     string
 	Title       string
-	Type        string
 	Description string
 	Parameters  map[string]Parameter
 	Template    *template.Template


### PR DESCRIPTION
## Description of Changes

Adds missing JSON marshal/unmarshal methods for `plugin.Config` and exports the `(plugin.Config).Plugin` field so that its fields can be used by the universal agent.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
