### PR TITLE
Namespace router outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.4] - 2020-10-07
+### Fixed
+- Router outputs were not namespaced correctly
+
 ## [0.12.3] - 2020-10-07
 ### Fixed
 - (De)serialization of JSON for plugin config structs

--- a/operator/builtin/input/k8sevent/go.sum
+++ b/operator/builtin/input/k8sevent/go.sum
@@ -131,6 +131,7 @@ github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=

--- a/operator/builtin/transformer/router/router.go
+++ b/operator/builtin/transformer/router/router.go
@@ -37,8 +37,8 @@ type RouterOperatorRouteConfig struct {
 }
 
 // Build will build a router operator from the supplied configuration
-func (c RouterOperatorConfig) Build(context operator.BuildContext) (operator.Operator, error) {
-	basicOperator, err := c.BasicConfig.Build(context)
+func (c RouterOperatorConfig) Build(bc operator.BuildContext) (operator.Operator, error) {
+	basicOperator, err := c.BasicConfig.Build(bc)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (c RouterOperatorConfig) Build(context operator.BuildContext) (operator.Ope
 		route := RouterOperatorRoute{
 			Labeler:    labeler,
 			Expression: compiled,
-			OutputIDs:  routeConfig.OutputIDs,
+			OutputIDs:  routeConfig.OutputIDs.WithNamespace(bc),
 		}
 		routes = append(routes, &route)
 	}

--- a/operator/builtin/transformer/router/router_test.go
+++ b/operator/builtin/transformer/router/router_test.go
@@ -145,14 +145,14 @@ func TestRouterOperator(t *testing.T) {
 			results := map[string]int{}
 			var labels map[string]string
 
-			mock1 := testutil.NewMockOperator("output1")
+			mock1 := testutil.NewMockOperator("$.output1")
 			mock1.On("Process", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 				results["output1"] = results["output1"] + 1
 				if entry, ok := args[1].(*entry.Entry); ok {
 					labels = entry.Labels
 				}
 			})
-			mock2 := testutil.NewMockOperator("output2")
+			mock2 := testutil.NewMockOperator("$.output2")
 			mock2.On("Process", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 				results["output2"] = results["output2"] + 1
 				if entry, ok := args[1].(*entry.Entry); ok {

--- a/operator/helper/writer.go
+++ b/operator/helper/writer.go
@@ -30,11 +30,7 @@ func (c WriterConfig) Build(bc operator.BuildContext) (WriterOperator, error) {
 	}
 
 	// Namespace all the output IDs
-	namespacedIDs := make([]string, 0, len(c.OutputIDs))
-	for _, id := range c.OutputIDs {
-		namespacedIDs = append(namespacedIDs, bc.PrependNamespace(id))
-	}
-
+	namespacedIDs := c.OutputIDs.WithNamespace(bc)
 	if len(namespacedIDs) == 0 {
 		namespacedIDs = bc.DefaultOutputIDs
 	}
@@ -107,6 +103,14 @@ func (w *WriterOperator) findOperator(operators []operator.Operator, operatorID 
 
 // OutputIDs is a collection of operator IDs used as outputs.
 type OutputIDs []string
+
+func (o OutputIDs) WithNamespace(bc operator.BuildContext) OutputIDs {
+	namespacedIDs := make([]string, 0, len(o))
+	for _, id := range o {
+		namespacedIDs = append(namespacedIDs, bc.PrependNamespace(id))
+	}
+	return namespacedIDs
+}
 
 // UnmarshalJSON will unmarshal a string or array of strings to OutputIDs.
 func (o *OutputIDs) UnmarshalJSON(bytes []byte) error {


### PR DESCRIPTION
## Description of Changes

With the new namespacing, I missed building the router with namespaced outputs. It's the only operator that overrides the default behavior of `SetOutputs`, so it should be the only one with this issue. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
