### PR TITLE
Use an explicit int64 in disk buffer so we can build on 32bit arch

### DIFF
--- a/operator/buffer/disk.go
+++ b/operator/buffer/disk.go
@@ -21,7 +21,7 @@ type DiskBufferConfig struct {
 	Type string `json:"type" yaml:"type"`
 
 	// MaxSize is the maximum size in bytes of the data file on disk
-	MaxSize int `json:"max_size" yaml:"max_size"`
+	MaxSize int64 `json:"max_size" yaml:"max_size"`
 
 	// Path is a path to a directory which contains the data and metadata files
 	Path string `json:"path" yaml:"path"`
@@ -90,7 +90,7 @@ type DiskBuffer struct {
 }
 
 // NewDiskBuffer creates a new DiskBuffer
-func NewDiskBuffer(maxDiskSize int) *DiskBuffer {
+func NewDiskBuffer(maxDiskSize int64) *DiskBuffer {
 	return &DiskBuffer{
 		maxBytes:          int64(maxDiskSize),
 		entryAdded:        make(chan int64, 1),


### PR DESCRIPTION
## Description of Changes

Builds for 32bit architectures were failing because we were trying to set a platform-width integer to a value that doesn't fit in an int32. This changes that field to an explicit int64. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
