### PR TITLE
Replace preserve with preserve_to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Removed `preserve` in favor of `preserve_at` to make it more clear that it may overwrite parsed fields
+- Removed `preserve` in favor of `preserve_to` to make it more clear that it may overwrite parsed fields
 
 ## [0.12.5] - 2020-10-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Removed `preserve` in favor of `preserve_at` to make it more clear that it may overwrite parsed fields
+
 ## [0.12.5] - 2020-10-07
 ### Added
 - `windows_eventlog_input` can now parse messages from the Security channel.

--- a/cmd/stanza/go.sum
+++ b/cmd/stanza/go.sum
@@ -529,6 +529,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.14.5/go.mod h1:UJ0EZAp832vCd54Wev9N1BM
 github.com/grpc-ecosystem/grpc-gateway v1.14.6/go.mod h1:zdiPV4Yse/1gnckTHtghG4GkDEdKCRJduHpTxT3/jcw=
 github.com/grpc-ecosystem/grpc-gateway v1.15.0 h1:ntPNC9TD/6l2XDenJZe6T5lSMg95thpV9sGAqHX4WU8=
 github.com/grpc-ecosystem/grpc-gateway v1.15.0/go.mod h1:vO11I9oWA+KsxmfFQPhLnnIb1VDE24M+pdxZFiuZcA8=
+github.com/grpc-ecosystem/grpc-gateway v1.15.2 h1:HC+hWRWf+v5zTMPyoaYTKIJih+4sd4XRWmj0qlG87Co=
+github.com/grpc-ecosystem/grpc-gateway v1.15.2/go.mod h1:vO11I9oWA+KsxmfFQPhLnnIb1VDE24M+pdxZFiuZcA8=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
@@ -1079,6 +1081,8 @@ go.opencensus.io v0.22.4 h1:LYy1Hy3MJdrCdMwwzxA/dRok4ejH+RwNGbuoD9fCjto=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opentelemetry.io/collector v0.12.0 h1:SQFxSQBqD8P0ki29xrH+LaB1gBpLxAWcnmUL9/yaDKE=
 go.opentelemetry.io/collector v0.12.0/go.mod h1:mKQha2MeRhJi0rHS8yvZlzFk28ZVBCf6qMTsjGX0n1Y=
+go.opentelemetry.io/collector v0.13.0 h1:w5DywMfxHIoGhomH382SJn95+TGQDTz5r9n4bBACe4Y=
+go.opentelemetry.io/collector v0.13.0/go.mod h1:UB7wWD7RrEx8GFSaUR47TO1GAqxSi5+Kq68tI1icwJk=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=

--- a/cmd/stanza/go.sum
+++ b/cmd/stanza/go.sum
@@ -527,8 +527,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.14.5/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/grpc-ecosystem/grpc-gateway v1.14.6/go.mod h1:zdiPV4Yse/1gnckTHtghG4GkDEdKCRJduHpTxT3/jcw=
-github.com/grpc-ecosystem/grpc-gateway v1.15.0 h1:ntPNC9TD/6l2XDenJZe6T5lSMg95thpV9sGAqHX4WU8=
-github.com/grpc-ecosystem/grpc-gateway v1.15.0/go.mod h1:vO11I9oWA+KsxmfFQPhLnnIb1VDE24M+pdxZFiuZcA8=
 github.com/grpc-ecosystem/grpc-gateway v1.15.2 h1:HC+hWRWf+v5zTMPyoaYTKIJih+4sd4XRWmj0qlG87Co=
 github.com/grpc-ecosystem/grpc-gateway v1.15.2/go.mod h1:vO11I9oWA+KsxmfFQPhLnnIb1VDE24M+pdxZFiuZcA8=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
@@ -1079,8 +1077,6 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4 h1:LYy1Hy3MJdrCdMwwzxA/dRok4ejH+RwNGbuoD9fCjto=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
-go.opentelemetry.io/collector v0.12.0 h1:SQFxSQBqD8P0ki29xrH+LaB1gBpLxAWcnmUL9/yaDKE=
-go.opentelemetry.io/collector v0.12.0/go.mod h1:mKQha2MeRhJi0rHS8yvZlzFk28ZVBCf6qMTsjGX0n1Y=
 go.opentelemetry.io/collector v0.13.0 h1:w5DywMfxHIoGhomH382SJn95+TGQDTz5r9n4bBACe4Y=
 go.opentelemetry.io/collector v0.13.0/go.mod h1:UB7wWD7RrEx8GFSaUR47TO1GAqxSi5+Kq68tI1icwJk=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/docs/operators/json_parser.md
+++ b/docs/operators/json_parser.md
@@ -4,16 +4,16 @@ The `json_parser` operator parses the string-type field selected by `parse_from`
 
 ### Configuration Fields
 
-| Field        | Default          | Description                                                                                                                                |
-| ---          | ---              | ---                                                                                                                                        |
-| `id`         | `json_parser`    | A unique identifier for the operator                                                                                                       |
-| `output`     | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                                           |
-| `parse_from` | $                | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                                                              |
-| `parse_to`   | $                | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                                                              |
-| `preserve`   | false            | Preserve the unparsed value on the record                                                                                                  |
-| `on_error`   | `send`           | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md)                                            |
-| `timestamp`  | `nil`            | An optional [timestamp](/docs/types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator |
-| `severity`   | `nil`            | An optional [severity](/docs/types/severity.md) block which will parse a severity field before passing the entry to the output operator    |
+| Field         | Default          | Description                                                                                                                                |
+| ---           | ---              | ---                                                                                                                                        |
+| `id`          | `json_parser`    | A unique identifier for the operator                                                                                                       |
+| `output`      | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                                           |
+| `parse_from`  | $                | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                                                              |
+| `parse_to`    | $                | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                                                              |
+| `preserve_at` |                  | Preserves the unparsed value at the specified [field](/docs/types/field.md)                                                                |
+| `on_error`    | `send`           | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md)                                            |
+| `timestamp`   | `nil`            | An optional [timestamp](/docs/types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator |
+| `severity`    | `nil`            | An optional [severity](/docs/types/severity.md) block which will parse a severity field before passing the entry to the output operator    |
 
 
 ### Example Configurations

--- a/docs/operators/json_parser.md
+++ b/docs/operators/json_parser.md
@@ -10,7 +10,7 @@ The `json_parser` operator parses the string-type field selected by `parse_from`
 | `output`      | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                                           |
 | `parse_from`  | $                | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                                                              |
 | `parse_to`    | $                | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                                                              |
-| `preserve_at` |                  | Preserves the unparsed value at the specified [field](/docs/types/field.md)                                                                |
+| `preserve_to` |                  | Preserves the unparsed value at the specified [field](/docs/types/field.md)                                                                |
 | `on_error`    | `send`           | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md)                                            |
 | `timestamp`   | `nil`            | An optional [timestamp](/docs/types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator |
 | `severity`    | `nil`            | An optional [severity](/docs/types/severity.md) block which will parse a severity field before passing the entry to the output operator    |

--- a/docs/operators/regex_parser.md
+++ b/docs/operators/regex_parser.md
@@ -11,7 +11,7 @@ The `regex_parser` operator parses the string-type field selected by `parse_from
 | `regex`       | required         | A [Go regular expression](https://github.com/google/re2/wiki/Syntax). The named capture groups will be extracted as fields in the parsed object |
 | `parse_from`  | $                | A [field](/docs/types/field.md) that indicates the field to be parsed                                                                           |
 | `parse_to`    | $                | A [field](/docs/types/field.md) that indicates the field to be parsed                                                                           |
-| `preserve_at` |                  | Preserves the unparsed value at the specified [field](/docs/types/field.md)                                                                     |
+| `preserve_to` |                  | Preserves the unparsed value at the specified [field](/docs/types/field.md)                                                                     |
 | `on_error`    | `send`           | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md)                                                 |
 | `timestamp`   | `nil`            | An optional [timestamp](/docs/types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator      |
 | `severity`    | `nil`            | An optional [severity](/docs/types/severity.md) block which will parse a severity field before passing the entry to the output operator         |

--- a/docs/operators/regex_parser.md
+++ b/docs/operators/regex_parser.md
@@ -4,17 +4,17 @@ The `regex_parser` operator parses the string-type field selected by `parse_from
 
 ### Configuration Fields
 
-| Field        | Default          | Description                                                                                                                                     |
-| ---          | ---              | ---                                                                                                                                             |
-| `id`         | `regex_parser`   | A unique identifier for the operator                                                                                                            |
-| `output`     | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                                                |
-| `regex`      | required         | A [Go regular expression](https://github.com/google/re2/wiki/Syntax). The named capture groups will be extracted as fields in the parsed object |
-| `parse_from` | $                | A [field](/docs/types/field.md) that indicates the field to be parsed                                                                           |
-| `parse_to`   | $                | A [field](/docs/types/field.md) that indicates the field to be parsed                                                                           |
-| `preserve`   | false            | Preserve the unparsed value on the record                                                                                                       |
-| `on_error`   | `send`           | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md)                                                 |
-| `timestamp`  | `nil`            | An optional [timestamp](/docs/types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator      |
-| `severity`   | `nil`            | An optional [severity](/docs/types/severity.md) block which will parse a severity field before passing the entry to the output operator         |
+| Field         | Default          | Description                                                                                                                                     |
+| ---           | ---              | ---                                                                                                                                             |
+| `id`          | `regex_parser`   | A unique identifier for the operator                                                                                                            |
+| `output`      | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                                                |
+| `regex`       | required         | A [Go regular expression](https://github.com/google/re2/wiki/Syntax). The named capture groups will be extracted as fields in the parsed object |
+| `parse_from`  | $                | A [field](/docs/types/field.md) that indicates the field to be parsed                                                                           |
+| `parse_to`    | $                | A [field](/docs/types/field.md) that indicates the field to be parsed                                                                           |
+| `preserve_at` |                  | Preserves the unparsed value at the specified [field](/docs/types/field.md)                                                                     |
+| `on_error`    | `send`           | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md)                                                 |
+| `timestamp`   | `nil`            | An optional [timestamp](/docs/types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator      |
+| `severity`    | `nil`            | An optional [severity](/docs/types/severity.md) block which will parse a severity field before passing the entry to the output operator         |
 
 ### Example Configurations
 

--- a/docs/operators/severity_parser.md
+++ b/docs/operators/severity_parser.md
@@ -9,7 +9,7 @@ The `severity_parser` operator sets the severity on an entry by parsing a value 
 | `id`          | required  | A unique identifier for the operator                                                            |
 | `output`      | required  | The `id` for the operator to send parsed entries to                                             |
 | `parse_from`  | required  | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                   |
-| `preserve_at` |           | Preserves the unparsed value at the specified [field](/docs/types/field.md)                     |
+| `preserve_to` |           | Preserves the unparsed value at the specified [field](/docs/types/field.md)                     |
 | `on_error`    | `send`    | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md) |
 | `preset`      | `default` | A predefined set of values that should be interpreted at specific severity levels               |
 | `mapping`     |           | A formatted set of values that should be interpreted as severity levels.                        |

--- a/docs/operators/severity_parser.md
+++ b/docs/operators/severity_parser.md
@@ -9,7 +9,7 @@ The `severity_parser` operator sets the severity on an entry by parsing a value 
 | `id`          | required  | A unique identifier for the operator                                                            |
 | `output`      | required  | The `id` for the operator to send parsed entries to                                             |
 | `parse_from`  | required  | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                   |
-| `preserve`    | false     | Preserve the unparsed value on the record                                                       |
+| `preserve_at` |           | Preserves the unparsed value at the specified [field](/docs/types/field.md)                     |
 | `on_error`    | `send`    | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md) |
 | `preset`      | `default` | A predefined set of values that should be interpreted at specific severity levels               |
 | `mapping`     |           | A formatted set of values that should be interpreted as severity levels.                        |

--- a/docs/operators/syslog_parser.md
+++ b/docs/operators/syslog_parser.md
@@ -10,7 +10,7 @@ The `syslog_parser` operator parses the string-type field selected by `parse_fro
 | `output`      | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                                           |
 | `parse_from`  | $                | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                                                              |
 | `parse_to`    | $                | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                                                              |
-| `preserve_at` |                  | Preserves the unparsed value at the specified [field](/docs/types/field.md)                                                                |
+| `preserve_to` |                  | Preserves the unparsed value at the specified [field](/docs/types/field.md)                                                                |
 | `on_error`    | `send`           | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md)                                            |
 | `protocol`    | required         | The protocol to parse the syslog messages as. Options are `rfc3164` and `rfc5424`                                                          |
 | `timestamp`   | `nil`            | An optional [timestamp](/docs/types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator |

--- a/docs/operators/syslog_parser.md
+++ b/docs/operators/syslog_parser.md
@@ -4,17 +4,17 @@ The `syslog_parser` operator parses the string-type field selected by `parse_fro
 
 ### Configuration Fields
 
-| Field        | Default          | Description                                                                                                                                     |
-| ---          | ---              | ---                                                                                                                                             |
-| `id`         | `syslog_parser`  | A unique identifier for the operator                                                                                                            |
-| `output`     | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                                                |
-| `parse_from` | $                | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                                                                   |
-| `parse_to`   | $                | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                                                                   |
-| `preserve`   | false            | Preserve the unparsed value on the record                                                                                                       |
-| `on_error`   | `send`           | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md)                                                 |
-| `protocol`   | required         | The protocol to parse the syslog messages as. Options are `rfc3164` and `rfc5424`                                                               |
-| `timestamp`  | `nil`            | An optional [timestamp](/docs/types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator      |
-| `severity`   | `nil`            | An optional [severity](/docs/types/severity.md) block which will parse a severity field before passing the entry to the output operator         |
+| Field         | Default          | Description                                                                                                                                |
+| ---           | ---              | ---                                                                                                                                        |
+| `id`          | `syslog_parser`  | A unique identifier for the operator                                                                                                       |
+| `output`      | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                                           |
+| `parse_from`  | $                | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                                                              |
+| `parse_to`    | $                | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                                                              |
+| `preserve_at` |                  | Preserves the unparsed value at the specified [field](/docs/types/field.md)                                                                |
+| `on_error`    | `send`           | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md)                                            |
+| `protocol`    | required         | The protocol to parse the syslog messages as. Options are `rfc3164` and `rfc5424`                                                          |
+| `timestamp`   | `nil`            | An optional [timestamp](/docs/types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator |
+| `severity`    | `nil`            | An optional [severity](/docs/types/severity.md) block which will parse a severity field before passing the entry to the output operator    |
 
 ### Example Configurations
 

--- a/docs/operators/time_parser.md
+++ b/docs/operators/time_parser.md
@@ -11,7 +11,7 @@ The `time_parser` operator sets the timestamp on an entry by parsing a value fro
 | `parse_from`  | required   | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                   |
 | `layout_type` | `strptime` | The type of timestamp. Valid values are `strptime`, `gotime`, and `epoch`                       |
 | `layout`      | required   | The exact layout of the timestamp to be parsed                                                  |
-| `preserve`    | false      | Preserve the unparsed value on the record                                                       |
+| `preserve_at` |            | Preserves the unparsed value at the specified [field](/docs/types/field.md)                     |
 | `on_error`    | `send`     | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md) |
 
 

--- a/docs/operators/time_parser.md
+++ b/docs/operators/time_parser.md
@@ -11,7 +11,7 @@ The `time_parser` operator sets the timestamp on an entry by parsing a value fro
 | `parse_from`  | required   | A [field](/docs/types/field.md) that indicates the field to be parsed as JSON                   |
 | `layout_type` | `strptime` | The type of timestamp. Valid values are `strptime`, `gotime`, and `epoch`                       |
 | `layout`      | required   | The exact layout of the timestamp to be parsed                                                  |
-| `preserve_at` |            | Preserves the unparsed value at the specified [field](/docs/types/field.md)                     |
+| `preserve_to` |            | Preserves the unparsed value at the specified [field](/docs/types/field.md)                     |
 | `on_error`    | `send`     | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md) |
 
 

--- a/operator/builtin/output/otlp/go.sum
+++ b/operator/builtin/output/otlp/go.sum
@@ -1048,6 +1048,7 @@ go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9E
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
+go.uber.org/zap v1.15.0/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
 go.uber.org/zap v1.16.0 h1:uFRZXykJGK9lLY4HtgSw44DnIcAM+kRBP7x5m+NpAOM=
 go.uber.org/zap v1.16.0/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/operator/helper/parser.go
+++ b/operator/helper/parser.go
@@ -14,8 +14,7 @@ func NewParserConfig(operatorID, operatorType string) ParserConfig {
 		TransformerConfig: NewTransformerConfig(operatorID, operatorType),
 		ParseFrom:         entry.NewRecordField(),
 		ParseTo:           entry.NewRecordField(),
-		Preserve:          false,
-		PreserveAt:        nil,
+		PreserveTo:        nil,
 	}
 }
 
@@ -25,8 +24,7 @@ type ParserConfig struct {
 
 	ParseFrom            entry.Field           `json:"parse_from" yaml:"parse_from"`
 	ParseTo              entry.Field           `json:"parse_to"   yaml:"parse_to"`
-	Preserve             bool                  `json:"preserve"   yaml:"preserve"`
-	PreserveAt           *entry.Field          `json:"preserve_at" yaml:"preserve_at"`
+	PreserveTo           *entry.Field          `json:"preserve_to" yaml:"preserve_to"`
 	TimeParser           *TimeParser           `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
 	SeverityParserConfig *SeverityParserConfig `json:"severity,omitempty" yaml:"severity,omitempty"`
 }
@@ -38,19 +36,11 @@ func (c ParserConfig) Build(context operator.BuildContext) (ParserOperator, erro
 		return ParserOperator{}, err
 	}
 
-	if c.ParseFrom.String() == c.ParseTo.String() && c.Preserve {
-		transformerOperator.Warnw(
-			"preserve is true, but parse_to is set to the same field as parse_from, "+
-				"which will cause the original value to be overwritten",
-			"operator_id", c.ID(),
-		)
-	}
-
 	parserOperator := ParserOperator{
 		TransformerOperator: transformerOperator,
 		ParseFrom:           c.ParseFrom,
 		ParseTo:             c.ParseTo,
-		PreserveAt:          c.PreserveAt,
+		PreserveTo:          c.PreserveTo,
 	}
 
 	if c.TimeParser != nil {
@@ -76,7 +66,7 @@ type ParserOperator struct {
 	TransformerOperator
 	ParseFrom      entry.Field
 	ParseTo        entry.Field
-	PreserveAt     *entry.Field
+	PreserveTo     *entry.Field
 	TimeParser     *TimeParser
 	SeverityParser *SeverityParser
 }
@@ -104,9 +94,9 @@ func (p *ParserOperator) ProcessWith(ctx context.Context, entry *entry.Entry, pa
 		return p.HandleEntryError(ctx, entry, errors.Wrap(err, "set parse_to"))
 	}
 
-	if p.PreserveAt != nil {
-		if err := entry.Set(p.PreserveAt, original); err != nil {
-			return p.HandleEntryError(ctx, entry, errors.Wrap(err, "set preserve_at"))
+	if p.PreserveTo != nil {
+		if err := entry.Set(p.PreserveTo, original); err != nil {
+			return p.HandleEntryError(ctx, entry, errors.Wrap(err, "set preserve_to"))
 		}
 	}
 

--- a/operator/helper/parser_test.go
+++ b/operator/helper/parser_test.go
@@ -281,7 +281,7 @@ func TestParserOutput(t *testing.T) {
 func TestParserWithPreserve(t *testing.T) {
 	cfg := NewParserConfig("test-id", "test-type")
 	preserveField := entry.NewRecordField("original")
-	cfg.PreserveAt = &preserveField
+	cfg.PreserveTo = &preserveField
 	parser, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
 
@@ -307,7 +307,7 @@ func TestParserWithPreserve(t *testing.T) {
 func TestParserWithOverwritingPreserve(t *testing.T) {
 	cfg := NewParserConfig("test-id", "test-type")
 	preserveField := entry.NewRecordField()
-	cfg.PreserveAt = &preserveField
+	cfg.PreserveTo = &preserveField
 	parser, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description of Changes

Replaces `preserve` with `preserve_at`, which takes an `entry.Field`. This makes it more clear when preserving the original would overwrite the parsed log entry. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
