### PR TITLE
Sample more aggressively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Removed `preserve` in favor of `preserve_to` to make it more clear that it may overwrite parsed fields
+- Updated our internal log sampling numbers to more aggressively sample repeated logs
 
 ## [0.12.5] - 2020-10-07
 ### Added

--- a/agent/builder.go
+++ b/agent/builder.go
@@ -84,7 +84,7 @@ func (b *LogAgentBuilder) Build() (*LogAgent, error) {
 
 	sampledLogger := b.logger.Desugar().WithOptions(
 		zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return zapcore.NewSamplerWithOptions(core, time.Second, 5, 100)
+			return zapcore.NewSamplerWithOptions(core, time.Second, 1, 10000)
 		}),
 	).Sugar()
 


### PR DESCRIPTION
## Description of Changes

Because if there is an error once, there will likely be many errors, we should be sampling more aggressively. Requested here: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1419


## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
