### PR TITLE
Elasticsearch tests and default values

### DIFF
--- a/operator/buffer/disk.go
+++ b/operator/buffer/disk.go
@@ -43,10 +43,15 @@ func NewDiskBufferConfig() *DiskBufferConfig {
 
 // Build creates a new Buffer from a DiskBufferConfig
 func (c DiskBufferConfig) Build(context operator.BuildContext, _ string) (Buffer, error) {
+	maxSize := c.MaxSize
+	if maxSize == 0 {
+		maxSize = 1 << 32
+	}
+
 	if c.Path == "" {
 		return nil, fmt.Errorf("missing required field 'path'")
 	}
-	b := NewDiskBuffer(c.MaxSize)
+	b := NewDiskBuffer(maxSize)
 	if err := b.Open(c.Path, c.Sync); err != nil {
 		return nil, err
 	}

--- a/operator/builtin/output/elastic/elastic_test.go
+++ b/operator/builtin/output/elastic/elastic_test.go
@@ -1,9 +1,17 @@
 package elastic
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/observiq/stanza/entry"
+	"github.com/observiq/stanza/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,4 +87,47 @@ func TestFindID(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, idx)
 	})
+}
+
+func TestElastic(t *testing.T) {
+	received := make(chan []byte, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+		received <- body
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	cfg := NewElasticOutputConfig("test")
+	cfg.Addresses = []string{ts.URL}
+
+	ops, err := cfg.Build(testutil.NewBuildContext(t))
+	require.NoError(t, err)
+	op := ops[0]
+	e := entry.New()
+	e.Record = "test"
+
+	require.NoError(t, op.Start())
+	op.Process(context.Background(), e)
+	select {
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "Timed out waiting for request")
+	case body := <-received:
+		dec := json.NewDecoder(bytes.NewReader(body))
+
+		var meta map[string]map[string]interface{}
+		err := dec.Decode(&meta)
+		require.NoError(t, err)
+
+		var entry map[string]interface{}
+		err = dec.Decode(&entry)
+		require.NoError(t, err)
+
+		require.Equal(t, "default", meta["index"]["_index"])
+		require.Equal(t, float64(0), entry["severity"])
+		require.Equal(t, "test", entry["record"])
+	}
 }

--- a/operator/flusher/flusher.go
+++ b/operator/flusher/flusher.go
@@ -49,9 +49,9 @@ func (c *Config) Build(buf buffer.Buffer, f FlushFunc, logger *zap.SugaredLogger
 		maxConcurrent = 4
 	}
 
-  maxWait := c.MaxWait.Raw()
-  if maxWait == time.Duration(0) {
-    maxWait = time.Second
+	maxWait := c.MaxWait.Raw()
+	if maxWait == time.Duration(0) {
+		maxWait = time.Second
 	}
 
 	maxChunkEntries := c.MaxChunkEntries

--- a/operator/helper/persister_test.go
+++ b/operator/helper/persister_test.go
@@ -22,7 +22,7 @@ func TestPersisterLoad(t *testing.T) {
 	db, err := database.OpenDatabase(filepath.Join(tempDir, "test.db"))
 	persister := NewScopedDBPersister(db, "test")
 	persister.Set("key", []byte("value"))
-	
+
 	err = persister.Sync()
 	require.NoError(t, err)
 

--- a/plugin/parameter_test.go
+++ b/plugin/parameter_test.go
@@ -274,4 +274,3 @@ func TestValidateValue(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
## Description of Changes

- Add a test that includes buffers, flushers, and network requests to the elasticsearch output as a sanity check. 
- Add sane buildtime defaults to buffers and flushers so that they are less of a footgun for plugin developers



## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
