### PR TITLE
Router default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - New parameter `if` to parser plugins to allow for easy conditional parsing without routers
+- New `default` parameter to the router to explicitly send unmatched entries to a specific operator(s)
 
 ## [0.13.1] - 2020-11-11
 ### Fixed

--- a/docs/operators/router.md
+++ b/docs/operators/router.md
@@ -10,10 +10,10 @@ An entry that does not match any of the routes is dropped and not processed furt
 
 ### Configuration Fields
 
-| Field    | Default  | Description                                                                                                                                                                                                                              |
-| ---      | ---      | ---                                                                                                                                                                                                                                      |
-| `id`     | `router` | A unique identifier for the operator                                                                                                                                                                                                     |
-| `routes` | required | A list of routes. See below for details                                                                                                                                                                                                  |
+| Field     | Default  | Description                                                                    | | ---       | ---      | ---                                                                            |
+| `id`      | `router` | A unique identifier for the operator                                           |
+| `routes`  | required | A list of routes. See below for details                                        |
+| `default` |          | The operator(s) that will receive any entries not matched by any of the routes |
 
 #### Route configuration
 

--- a/operator/builtin/transformer/router/router.go
+++ b/operator/builtin/transformer/router/router.go
@@ -27,6 +27,7 @@ func NewRouterOperatorConfig(operatorID string) *RouterOperatorConfig {
 type RouterOperatorConfig struct {
 	helper.BasicConfig `yaml:",inline"`
 	Routes             []*RouterOperatorRouteConfig `json:"routes" yaml:"routes"`
+	Default            helper.OutputIDs             `json:"default" yaml:"default"`
 }
 
 // RouterOperatorRouteConfig is the configuration of a route on a router operator
@@ -41,6 +42,14 @@ func (c RouterOperatorConfig) Build(bc operator.BuildContext) ([]operator.Operat
 	basicOperator, err := c.BasicConfig.Build(bc)
 	if err != nil {
 		return nil, err
+	}
+
+	if c.Default != nil {
+		defaultRoute := &RouterOperatorRouteConfig{
+			Expression: "true",
+			OutputIDs:  c.Default,
+		}
+		c.Routes = append(c.Routes, defaultRoute)
 	}
 
 	routes := make([]*RouterOperatorRoute, 0, len(c.Routes))
@@ -142,6 +151,7 @@ func (p *RouterOperator) SetOutputs(operators []operator.Operator) error {
 		}
 		route.OutputOperators = outputOperators
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description of Changes

Add a `default` parameter to the router to explicitly send unmatched entries to another output. 

Example:
Config:
```yaml
pipeline:
- type: stdin
- type: router
  routes:
    - expr: "$record == 'test'"
      output: stdout2
      labels:
        stdout: "2"
  default: stdout1

- id: stdout1
  type: stdout

- id: stdout2
  type: stdout
```
Command:
```bash
(echo 'nottest' ; echo "test" ) | stanza -c ./dev/config.yaml | jq
```

Output: 
```json
{
  "timestamp": "2020-11-13T11:56:48.836979-05:00",
  "severity": 0,
  "record": "nottest"
}
{
  "timestamp": "2020-11-13T11:56:48.837122-05:00",
  "severity": 0,
  "labels": {
    "stdout": "2"
  },
  "record": "test"
}
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
