### PR TITLE
Bytesize

### DIFF
--- a/docs/operators/file_input.md
+++ b/docs/operators/file_input.md
@@ -4,22 +4,22 @@ The `file_input` operator reads logs from files. It will place the lines read in
 
 ### Configuration Fields
 
-| Field               | Default          | Description                                                                                                        |
-| ---                 | ---              | ---                                                                                                                |
-| `id`                | `file_input`     | A unique identifier for the operator                                                                               |
-| `output`            | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                   |
-| `include`           | required         | A list of file glob patterns that match the file paths to be read                                                  |
-| `exclude`           | []               | A list of file glob patterns to exclude from reading                                                               |
-| `poll_interval`     | 200ms            | The duration between filesystem polls                                                                              |
-| `multiline`         |                  | A `multiline` configuration block. See below for details                                                           |
-| `write_to`          | $                | The record [field](/docs/types/field.md) written to when creating a new log entry                                  |
-| `encoding`          | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options               |
-| `include_file_name` | `true`           | Whether to add the file name as the label `file_name`                                                              |
-| `include_file_path` | `false`          | Whether to add the file path as the label `file_path`                                                              |
-| `start_at`          | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
-| `max_log_size`      | 1048576          | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |
-| `labels`            | {}               | A map of `key: value` labels to add to the entry's labels                                                          |
-| `resource`          | {}               | A map of `key: value` labels to add to the entry's resource                                                        |
+| Field               | Default          | Description                                                                                                                                                                                |
+| ---                 | ---              | ---                                                                                                                                                                                        |
+| `id`                | `file_input`     | A unique identifier for the operator                                                                                                                                                       |
+| `output`            | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                                                                                           |
+| `include`           | required         | A list of file glob patterns that match the file paths to be read                                                                                                                          |
+| `exclude`           | []               | A list of file glob patterns to exclude from reading                                                                                                                                       |
+| `poll_interval`     | 200ms            | The duration between filesystem polls                                                                                                                                                      |
+| `multiline`         |                  | A `multiline` configuration block. See below for details                                                                                                                                   |
+| `write_to`          | $                | The record [field](/docs/types/field.md) written to when creating a new log entry                                                                                                          |
+| `encoding`          | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options                                                                                       |
+| `include_file_name` | `true`           | Whether to add the file name as the label `file_name`                                                                                                                                      |
+| `include_file_path` | `false`          | Whether to add the file path as the label `file_path`                                                                                                                                      |
+| `start_at`          | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                                                                                                    |
+| `max_log_size`      | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory. See [ByteSize](/docs/types/bytesize.md) for details on allowed values. |
+| `labels`            | {}               | A map of `key: value` labels to add to the entry's labels                                                                                                                                  |
+| `resource`          | {}               | A map of `key: value` labels to add to the entry's resource                                                                                                                                |
 
 Note that by default, no logs will be read unless the monitored file is actively being written to because `start_at` defaults to `end`.
 

--- a/docs/types/buffer.md
+++ b/docs/types/buffer.md
@@ -49,13 +49,13 @@ be logs that are lost or a corruption of the database.
 
 Disk buffers are configured by setting the `type` field of the `buffer` block on an output to `disk`. Other fields are described below:
 
-| Field             | Default             | Description                                                                                                                              |
-| ---               | ---                 | ---                                                                                                                                      |
-| `max_size`        | `4294967296` (4GiB) | The maximum size of the disk buffer file in bytes                                                                                        |
-| `max_chunk_size`  | 1000                | The maximum number of entries that are read from the buffer by default                                                                   |
-| `max_chunk_delay` | 1s                  | The maximum amount of time that a reader will wait to batch entries into a chunk                                                         |
-| `path`            | required            | The path to the directory which will contain the disk buffer data                                                                        |
-| `sync`            | `true`              | Whether to open the database files with the O_SYNC flag. Disabling this improves performance, but relaxes guarantees about log delivery. |
+| Field             | Default  | Description                                                                                                                              |
+| ---               | ---      | ---                                                                                                                                      |
+| `max_size`        | `4GiB`   | The maximum size of the disk buffer file in bytes. See [ByteSize](/docs/types/bytesize.md) for details on allowed values.                |
+| `max_chunk_size`  | 1000     | The maximum number of entries that are read from the buffer by default                                                                   |
+| `max_chunk_delay` | 1s       | The maximum amount of time that a reader will wait to batch entries into a chunk                                                         |
+| `path`            | required | The path to the directory which will contain the disk buffer data                                                                        |
+| `sync`            | `true`   | Whether to open the database files with the O_SYNC flag. Disabling this improves performance, but relaxes guarantees about log delivery. |
 
 Example:
 ```yaml

--- a/docs/types/bytesize.md
+++ b/docs/types/bytesize.md
@@ -1,0 +1,28 @@
+# ByteSize
+
+ByteSizes are a type that allows specifying a number of bytes in a human-readable format. See the examples for details.
+
+
+## Examples
+
+### Various ways to specify 5000 bytes
+
+```yaml
+- type: some_operator
+  bytes: 5000
+```
+
+```yaml
+- type: some_operator
+  bytes: 5kb
+```
+
+```yaml
+- type: some_operator
+  bytes: 4.88KiB
+```
+
+```yaml
+- type: some_operator
+  bytes: 5e3
+```

--- a/operator/buffer/disk.go
+++ b/operator/buffer/disk.go
@@ -22,7 +22,7 @@ type DiskBufferConfig struct {
 	Type string `json:"type" yaml:"type"`
 
 	// MaxSize is the maximum size in bytes of the data file on disk
-	MaxSize int64 `json:"max_size" yaml:"max_size"`
+	MaxSize helper.ByteSize `json:"max_size" yaml:"max_size"`
 
 	// Path is a path to a directory which contains the data and metadata files
 	Path string `json:"path" yaml:"path"`
@@ -57,7 +57,7 @@ func (c DiskBufferConfig) Build(context operator.BuildContext, _ string) (Buffer
 	if c.Path == "" {
 		return nil, fmt.Errorf("missing required field 'path'")
 	}
-	b := NewDiskBuffer(maxSize)
+	b := NewDiskBuffer(int64(maxSize))
 	if err := b.Open(c.Path, c.Sync); err != nil {
 		return nil, err
 	}

--- a/operator/builtin/input/file/config.go
+++ b/operator/builtin/input/file/config.go
@@ -45,7 +45,7 @@ type InputConfig struct {
 	IncludeFileName bool             `json:"include_file_name,omitempty" yaml:"include_file_name,omitempty"`
 	IncludeFilePath bool             `json:"include_file_path,omitempty" yaml:"include_file_path,omitempty"`
 	StartAt         string           `json:"start_at,omitempty"          yaml:"start_at,omitempty"`
-	MaxLogSize      int              `json:"max_log_size,omitempty"      yaml:"max_log_size,omitempty"`
+	MaxLogSize      helper.ByteSize  `json:"max_log_size,omitempty"      yaml:"max_log_size,omitempty"`
 	Encoding        string           `json:"encoding,omitempty"          yaml:"encoding,omitempty"`
 }
 
@@ -127,7 +127,7 @@ func (c InputConfig) Build(context operator.BuildContext) ([]operator.Operator, 
 		firstCheck:       true,
 		cancel:           func() {},
 		knownFiles:       make([]*Reader, 0, 10),
-		MaxLogSize:       c.MaxLogSize,
+		MaxLogSize:       int(c.MaxLogSize),
 		SeenPaths:        make(map[string]struct{}, 100),
 	}
 

--- a/operator/helper/bytesize.go
+++ b/operator/helper/bytesize.go
@@ -1,0 +1,83 @@
+package helper
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type ByteSize int64
+
+func (h *ByteSize) UnmarshalJSON(raw []byte) error {
+	return h.unmarshalShared(func(i interface{}) error {
+		return json.Unmarshal(raw, &i)
+	})
+}
+
+func (h *ByteSize) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return h.unmarshalShared(unmarshal)
+}
+
+var byteSizeRegex = regexp.MustCompile(`^([0-9]+\.?[0-9]*)\s*([kKmMgGtTpP]i?[bB])?$`)
+
+func (h *ByteSize) unmarshalShared(unmarshal func(interface{}) error) error {
+	var intType int64
+	if err := unmarshal(&intType); err == nil {
+		*h = ByteSize(intType)
+		return nil
+	}
+
+	var floatType float64
+	if err := unmarshal(&floatType); err == nil {
+		*h = ByteSize(int64(floatType))
+		return nil
+	}
+
+	var stringType string
+	if err := unmarshal(&stringType); err != nil {
+		return fmt.Errorf("failed to unmarshal to int64, float64, or string: %s", err)
+	}
+
+	matches := byteSizeRegex.FindStringSubmatch(stringType)
+	if matches == nil {
+		return fmt.Errorf("invalid byte size '%s'", stringType)
+	}
+
+	numeral, err := strconv.ParseFloat(matches[1], 32)
+	if err != nil {
+		return fmt.Errorf("invalid numeric base '%s'", matches[1])
+	}
+
+	var multiplier float64
+	switch strings.ToLower(matches[2]) {
+	case "":
+		multiplier = 1
+	case "kb":
+		multiplier = 1000
+	case "kib":
+		multiplier = 1024
+	case "mb":
+		multiplier = 1000 * 1000
+	case "mib":
+		multiplier = 1024 * 1024
+	case "gb":
+		multiplier = 1000 * 1000 * 1000
+	case "gib":
+		multiplier = 1024 * 1024 * 1024
+	case "tb":
+		multiplier = 1000 * 1000 * 1000 * 1000
+	case "tib":
+		multiplier = 1024 * 1024 * 1024 * 1024
+	case "pb":
+		multiplier = 1000 * 1000 * 1000 * 1000 * 1000
+	case "pib":
+		multiplier = 1024 * 1024 * 1024 * 1024 * 1024
+	default:
+		return fmt.Errorf("invalid unit '%s'", matches[2])
+	}
+
+	*h = ByteSize(int64(multiplier * numeral))
+	return nil
+}

--- a/operator/helper/bytesize_test.go
+++ b/operator/helper/bytesize_test.go
@@ -1,0 +1,119 @@
+package helper
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestByteSizeUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		input       string
+		expected    ByteSize
+		expectError bool
+	}{
+		{`1`, 1, false},
+		{`1`, 1, false},
+		{`1`, 1, false},
+		{`3.3`, 3, false},
+		{`0`, 0, false},
+		{`10101010`, 10101010, false},
+		{`0.01`, 0, false},
+		{`"1"`, 1, false},
+		{`"1kb"`, 1000, false},
+		{`"1KB"`, 1000, false},
+		{`"1kib"`, 1024, false},
+		{`"1KiB"`, 1024, false},
+		{`"1mb"`, 1000 * 1000, false},
+		{`"1mib"`, 1024 * 1024, false},
+		{`"1gb"`, 1000 * 1000 * 1000, false},
+		{`"1gib"`, 1024 * 1024 * 1024, false},
+		{`"1tb"`, 1000 * 1000 * 1000 * 1000, false},
+		{`"1tib"`, 1024 * 1024 * 1024 * 1024, false},
+		{`"1pB"`, 1000 * 1000 * 1000 * 1000 * 1000, false},
+		{`"1pib"`, 1024 * 1024 * 1024 * 1024 * 1024, false},
+		{`1e3`, 1000, false},
+		{`"3ii3"`, 0, true},
+		{`3ii3`, 0, true},
+		{`--ii3`, 0, true},
+		{`{"test":"val"}`, 0, true},
+	}
+
+	for i, tc := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var bs ByteSize
+			err := json.Unmarshal([]byte(tc.input), &bs)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, bs)
+		})
+	}
+}
+
+func TestByteSizeUnmarshalYAML(t *testing.T) {
+	cases := []struct {
+		input       string
+		expected    ByteSize
+		expectError bool
+	}{
+		{`1`, 1, false},
+		{`1`, 1, false},
+		{`3.3`, 3, false},
+		{`0`, 0, false},
+		{`10101010`, 10101010, false},
+		{`0.01`, 0, false},
+		{`"1"`, 1, false},
+		{`"1kb"`, 1000, false},
+		{`"1KB"`, 1000, false},
+		{`"1kib"`, 1024, false},
+		{`"1KiB"`, 1024, false},
+		{`"1mb"`, 1000 * 1000, false},
+		{`"1mib"`, 1024 * 1024, false},
+		{`"1gb"`, 1000 * 1000 * 1000, false},
+		{`"1gib"`, 1024 * 1024 * 1024, false},
+		{`"1tb"`, 1000 * 1000 * 1000 * 1000, false},
+		{`"1tib"`, 1024 * 1024 * 1024 * 1024, false},
+		{`"1pB"`, 1000 * 1000 * 1000 * 1000 * 1000, false},
+		{`"1pib"`, 1024 * 1024 * 1024 * 1024 * 1024, false},
+		{`1`, 1, false},
+		{`1kb`, 1000, false},
+		{`1KB`, 1000, false},
+		{`1kib`, 1024, false},
+		{`1KiB`, 1024, false},
+		{`1mb`, 1000 * 1000, false},
+		{`1mib`, 1024 * 1024, false},
+		{`1gb`, 1000 * 1000 * 1000, false},
+		{`1gib`, 1024 * 1024 * 1024, false},
+		{`1tb`, 1000 * 1000 * 1000 * 1000, false},
+		{`1tib`, 1024 * 1024 * 1024 * 1024, false},
+		{`1pB`, 1000 * 1000 * 1000 * 1000 * 1000, false},
+		{`1pib`, 1024 * 1024 * 1024 * 1024 * 1024, false},
+		{`"3ii3"`, 0, true},
+		{`3ii3`, 0, true},
+		{`--ii3`, 0, true},
+		{`{"test":"val"}`, 0, true},
+		{`test: val`, 0, true},
+		{`1e3`, 1000, false},
+	}
+
+	for i, tc := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var bs ByteSize
+			err := yaml.Unmarshal([]byte(tc.input), &bs)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, bs)
+		})
+	}
+}

--- a/operator/helper/bytesize_test.go
+++ b/operator/helper/bytesize_test.go
@@ -9,40 +9,41 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-func TestByteSizeUnmarshalJSON(t *testing.T) {
-	cases := []struct {
-		input       string
-		expected    ByteSize
-		expectError bool
-	}{
-		{`1`, 1, false},
-		{`1`, 1, false},
-		{`1`, 1, false},
-		{`3.3`, 3, false},
-		{`0`, 0, false},
-		{`10101010`, 10101010, false},
-		{`0.01`, 0, false},
-		{`"1"`, 1, false},
-		{`"1kb"`, 1000, false},
-		{`"1KB"`, 1000, false},
-		{`"1kib"`, 1024, false},
-		{`"1KiB"`, 1024, false},
-		{`"1mb"`, 1000 * 1000, false},
-		{`"1mib"`, 1024 * 1024, false},
-		{`"1gb"`, 1000 * 1000 * 1000, false},
-		{`"1gib"`, 1024 * 1024 * 1024, false},
-		{`"1tb"`, 1000 * 1000 * 1000 * 1000, false},
-		{`"1tib"`, 1024 * 1024 * 1024 * 1024, false},
-		{`"1pB"`, 1000 * 1000 * 1000 * 1000 * 1000, false},
-		{`"1pib"`, 1024 * 1024 * 1024 * 1024 * 1024, false},
-		{`1e3`, 1000, false},
-		{`"3ii3"`, 0, true},
-		{`3ii3`, 0, true},
-		{`--ii3`, 0, true},
-		{`{"test":"val"}`, 0, true},
-	}
+type testCase struct {
+	input       string
+	expected    ByteSize
+	expectError bool
+}
 
-	for i, tc := range cases {
+var sharedTestCases = []testCase{
+	{`1`, 1, false},
+	{`3.3`, 3, false},
+	{`0`, 0, false},
+	{`10101010`, 10101010, false},
+	{`0.01`, 0, false},
+	{`"1"`, 1, false},
+	{`"1kb"`, 1000, false},
+	{`"1KB"`, 1000, false},
+	{`"1kib"`, 1024, false},
+	{`"1KiB"`, 1024, false},
+	{`"1mb"`, 1000 * 1000, false},
+	{`"1mib"`, 1024 * 1024, false},
+	{`"1gb"`, 1000 * 1000 * 1000, false},
+	{`"1gib"`, 1024 * 1024 * 1024, false},
+	{`"1tb"`, 1000 * 1000 * 1000 * 1000, false},
+	{`"1tib"`, 1024 * 1024 * 1024 * 1024, false},
+	{`"1pB"`, 1000 * 1000 * 1000 * 1000 * 1000, false},
+	{`"1pib"`, 1024 * 1024 * 1024 * 1024 * 1024, false},
+	{`1e3`, 1000, false},
+	{`"3ii3"`, 0, true},
+	{`3ii3`, 0, true},
+	{`--ii3`, 0, true},
+	{`{"test":"val"}`, 0, true},
+	{`1e3`, 1000, false},
+}
+
+func TestByteSizeUnmarshalJSON(t *testing.T) {
+	for i, tc := range sharedTestCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			var bs ByteSize
 			err := json.Unmarshal([]byte(tc.input), &bs)
@@ -58,31 +59,7 @@ func TestByteSizeUnmarshalJSON(t *testing.T) {
 }
 
 func TestByteSizeUnmarshalYAML(t *testing.T) {
-	cases := []struct {
-		input       string
-		expected    ByteSize
-		expectError bool
-	}{
-		{`1`, 1, false},
-		{`1`, 1, false},
-		{`3.3`, 3, false},
-		{`0`, 0, false},
-		{`10101010`, 10101010, false},
-		{`0.01`, 0, false},
-		{`"1"`, 1, false},
-		{`"1kb"`, 1000, false},
-		{`"1KB"`, 1000, false},
-		{`"1kib"`, 1024, false},
-		{`"1KiB"`, 1024, false},
-		{`"1mb"`, 1000 * 1000, false},
-		{`"1mib"`, 1024 * 1024, false},
-		{`"1gb"`, 1000 * 1000 * 1000, false},
-		{`"1gib"`, 1024 * 1024 * 1024, false},
-		{`"1tb"`, 1000 * 1000 * 1000 * 1000, false},
-		{`"1tib"`, 1024 * 1024 * 1024 * 1024, false},
-		{`"1pB"`, 1000 * 1000 * 1000 * 1000 * 1000, false},
-		{`"1pib"`, 1024 * 1024 * 1024 * 1024 * 1024, false},
-		{`1`, 1, false},
+	additionalCases := []testCase{
 		{`1kb`, 1000, false},
 		{`1KB`, 1000, false},
 		{`1kib`, 1024, false},
@@ -95,14 +72,10 @@ func TestByteSizeUnmarshalYAML(t *testing.T) {
 		{`1tib`, 1024 * 1024 * 1024 * 1024, false},
 		{`1pB`, 1000 * 1000 * 1000 * 1000 * 1000, false},
 		{`1pib`, 1024 * 1024 * 1024 * 1024 * 1024, false},
-		{`"3ii3"`, 0, true},
-		{`3ii3`, 0, true},
-		{`--ii3`, 0, true},
-		{`{"test":"val"}`, 0, true},
 		{`test: val`, 0, true},
-		{`1e3`, 1000, false},
 	}
 
+	cases := append(sharedTestCases, additionalCases...)
 	for i, tc := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			var bs ByteSize


### PR DESCRIPTION
## Description of Changes

Adds type `helper.ByteSize` that allows users to configure byte values in a more human-readable format. For example, the file input `max_log_size` can now be configured as `5000`, `5kb`, `4.88KiB`, or `5e3`. Fixes #135. Closes #153.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
