### PR TITLE
Fix new errors in go 1.15

### DIFF
--- a/operator/builtin/input/forward/forward_test.go
+++ b/operator/builtin/input/forward/forward_test.go
@@ -45,7 +45,7 @@ func TestForwardInput(t *testing.T) {
 	_, port, err := net.SplitHostPort(forwardInput.ln.Addr().String())
 	require.NoError(t, err)
 
-	_, err = http.Post(fmt.Sprintf("http://localhost:%s", port), "application/json", &buf)
+	_, err = http.Post(fmt.Sprintf("http://127.0.0.1:%s", port), "application/json", &buf)
 	require.NoError(t, err)
 
 	select {
@@ -104,7 +104,7 @@ func TestForwardInputTLS(t *testing.T) {
 		},
 	}
 
-	_, err = client.Post(fmt.Sprintf("https://localhost:%s", port), "application/json", &buf)
+	_, err = client.Post(fmt.Sprintf("https://127.0.0.1:%s", port), "application/json", &buf)
 	require.NoError(t, err)
 
 	select {
@@ -138,85 +138,84 @@ func createCertFiles(t *testing.T) (cert, key string) {
 	return certFile.Name(), keyFile.Name()
 }
 
-// openssl genrsa -out private.key 4096
-var privateKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
-MIIJKAIBAAKCAgEApuAxisIDNYec13UCBrH20OkVoscgS7UnzNF2hGXKEz5wRAcl
-aHSVf+aTJob11Bz3d6I1ulDY1qsim8DCIoVHaZHGCuhQ+cpYkgL1TKGh/imVbNAD
-SUX263mxuvBqlq/GAMPuQ2BxFraQrf/tZlF9WxIFqCngPioalldy0fepkGO6sqxU
-X4p12S6RHaN3hxz7WHegyTV5NUvebJj1jZF8IzlNQrhduMWXHrSpHjqNHiHbee9y
-UzTKgfBX2jzurg2leyw7h653WhiX46PQry4WyxqqR6yHhbth2K+kI0XeEXGpjfOP
-USOhkAbW1U68z3Y01VGimH9TVPVqXFEdVYtWMtB+BWutiYehDqgNa/bBwHW8fznG
-INhJ0EI/tMXoAu0CDWYkd3g58WBiIV6W3zGfcNgF8mpj3FJtIFjCxZz0Q7zkTFhV
-OE0E8/ltlAnLsDQ2UyQ6OwOq2AvvLQYcISD8YrnTCGlFRAlLn+qKEzw3l4c1k0XB
-4EzeO4prAaduo20uVgRBl/x3c+Wv90c9xCd/USV3poWz2lTXTVv3oarMAdQlQ+88
-ZMT7OOagkwwxgEW8vj4xIMxQCj8FFYZrZnPYRUq4qU17f9SjZfc+E6CLfqAzUiBx
-ZO/Zbrnam/8GVxK0h8SaiXum8UQKrJhWutrQ6mB3RFHwjfGzSFxEbXSA5X0CAwEA
-AQKCAgABtBYtYW+g80JxnJspsFVhqo9y+u9kdnPyjkzUaymV6rRArYX/O/lutc7Y
-vNXzlVwdV4WO4lZkUpjm2B/jNFMXS8qmv9pbwmoHC4qvfpLlwkzpMHJoJBOyMarT
-yrJ72U1/IoDjJS/iWHi/nfYxbjGGZXezUMIeQFXHJRth81JCzBHS0xmFZCdx0Rzg
-HZQRyAT00TvN8gLLvXuGxkTzbgHDZklYngMu6K1zPcrgKR7ZqOTRqNUU7lwG2Yo8
-CxUwp6kByeDNsMU9ITUjuL9fmmvXJO2KD8POZKxKBvj49zSeHvfpIAxdeqyiiL9W
-rBgXUhCWAOBVCC+0lVDBon5XKjX2CJs0ix68bYr5r2sFRIrzJMW9xWpJ/8tZ2YRM
-I1dyCr4Qt2aXgnHXBg2mjX11CSRLWQY9OIR0x9szAVXbm2ddThtSL5y4WxDk/Lc3
-tl4tNTCRM9szCb0jK3lWSYQCihfnBQWKE9p6MG6xHng+m0NgolWLvbSlSiKTXIH5
-GvfBAnZ2OBfXZLiuwsiWCD8TxWju3aFMuEx3D2TY866fdU9m/EeajWxgXos7G/qc
-K26hykgYZIwfiWZUzzB5sm7tYRqFYn8hZMvRR25jxNjoezUii0PMGlLwsSchhrGd
-DWue10gMaqbY1ePt1QbhTe8LPL9Owpriy/dIQ9LlSHMzU6CvYQKCAQEA2T0o+j6Y
-oK2USiJ7iJm0x4fKoD0IXvB72uJtdbeDJk1bxxut6gquQEbUJ8GiSHjOwruJj89R
-MsVcBR+4l8o0LHSlXvWcI0Utjjb+4KY/k9HZXK2JJLVKYfAMy+jMvQUiUrfiPVfa
-UuJYRn98K169kG60TxXZctafGETB1eDXYUB5kUip0ukAhUP9pfZ6/ZFileET05Rq
-hJU4/DBHwghj1uTUwVl150xcf2L7EwpKHYpebERFY951AVO17v1IAnAaIsn/ynTV
-zefrIQE4C5dR4c0/UmfkG+l5fCdyghTUcXEOq2lZXCmucfKqtAs4soSTdEZtKhKk
-l4RGhTFK9Pg++QKCAQEAxKaXcI+j4XCFUEEod0HNy7b8GPBBYwVH05ne/CnY3T3k
-uCwGxGOB7DB/q+xhCMkTnIcoqPU+FtygiOEQXS/pgB/yYkIoTHm6UqUB/rahd4it
-qMhuKeTAUvBLJEZxDO7KMI3oy6rQTNeoZGFsx2HiHDVuXXWw1kEz8phuJKUl45HC
-+y0rLDS5OaPqAUjPSpGa7OTicWHh5nzggyVumTldDwLj4WGsUEBnnImvrpw4fG0L
-xXuOrP2OiVnJn5wcIp3v1jp4jzC6YrKaH9UH7RzU9iL3luriXukxYsO2rUioKxBP
-4sDhxy9N70k+bGOM86pHpkye9hc457Tlxg169WOHpQKCAQAhrYmcwfeHcWF73Lyq
-AKo2BKc1EEEr9rw8wr2Vck2ysmt4AqKDlgRNkq1xPGOcOJ5VMh2xXcKIzG/nm3NS
-lNZhzfOVNR5vmVnmokABM8THddDsvTp1pmVRqZVSR1T2OMWJbVh1ihkeoFhvFXR6
-hMV+jqsFV63OT9d6O66RKbo6KXSvQUSSneymvFOmVv/aL5/I/IvGUUvyIfAjqJh3
-TDWuKuuQzf2pTf1JAl9KJF45FiptPmhDg0lAW2npEvsG5boniolNKa+7rCiXhUjb
-Ayp+hwM6E0EZ0qgyxyrJX9FPhOdxS3O/Bfc1UxmDr/mqM0No00I5M4qwsqD8JRgp
-whKBAoIBADevbObE5gUqlbWaHdlXWu06zbxKHFnr3uD+i3QgbXaI1kGIxgnKm7nE
-KgMHFpskRVdnto3RlFlo9FSOVtHshVRwt3Q3g63UMnzAmQYFtUdh/rrytq9KRWO3
-A7Ar+ktNOxfwt2Ek54M69kYmiGUVRK/0OWJht0eUgx9JJrddxJLibbIuojEMZP77
-eYIPmhNlk9dNIQo2S3+3EORSLzVYVw+vI9RokiDPfAeJvaPWPPCO+GxdhpNZ4Yjn
-Uf7Od/EdhBLHz+fMRps4NAibjHkKVwuz7yRfMubpZcCv5wS+tFAteFGfiM+ch5cg
-yHps3jcJmuxuefz5qnWCdiZVHuJp4rkCggEBAIYU1OBmITWMQgzxUXrEaGoXWKGD
-TClWOnC9kzkjG29E1xse+DGBX7g7DaXLbO/VGylZPFJqqxFFCBhwGOGidXEz3I0O
-SgsW5Vy+NGUDJhPpsWLP5ONZgjgBG7YwXV8viOl06JfjvKXtvVq3kBfBAYsJEf+w
-LAZxek7KjVqscFdTrE1hdBEJ6cemw/hsvqdExMe8KBzy9ASGT4kiGiiNKq9nyIHl
-DePwbufao/2YXXg0f9JOjP7g9oUHQXQ1QAUJpa/Q5tx9qZZfgvtnNbGdCzLd2AB1
-QMxKLNBgkOReCJdVpTbhyzfQ68wJN4EhXu5F3DsV3V1Rn95MqvyY/eUFyCg=
------END RSA PRIVATE KEY-----`)
+/*
+ openssl req -x509 -nodes -newkey rsa:2048 -keyout key.pem -out cert.pem -config san.cnf
+ Generated with the following san.cnf:
 
-// openssl req -new -x509 -sha256 -days 1825 -key private.key -out public.crt
-// All default options, but with Common Name: localhost
-var publicCrt = []byte(`-----BEGIN CERTIFICATE-----
-MIIEpDCCAowCCQCxsoq2/xOeGzANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls
-b2NhbGhvc3QwHhcNMjAxMTE3MjEzNjQ1WhcNMjUxMTE2MjEzNjQ1WjAUMRIwEAYD
-VQQDDAlsb2NhbGhvc3QwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCm
-4DGKwgM1h5zXdQIGsfbQ6RWixyBLtSfM0XaEZcoTPnBEByVodJV/5pMmhvXUHPd3
-ojW6UNjWqyKbwMIihUdpkcYK6FD5yliSAvVMoaH+KZVs0ANJRfbrebG68GqWr8YA
-w+5DYHEWtpCt/+1mUX1bEgWoKeA+KhqWV3LR96mQY7qyrFRfinXZLpEdo3eHHPtY
-d6DJNXk1S95smPWNkXwjOU1CuF24xZcetKkeOo0eIdt573JTNMqB8FfaPO6uDaV7
-LDuHrndaGJfjo9CvLhbLGqpHrIeFu2HYr6QjRd4RcamN849RI6GQBtbVTrzPdjTV
-UaKYf1NU9WpcUR1Vi1Yy0H4Fa62Jh6EOqA1r9sHAdbx/OcYg2EnQQj+0xegC7QIN
-ZiR3eDnxYGIhXpbfMZ9w2AXyamPcUm0gWMLFnPRDvORMWFU4TQTz+W2UCcuwNDZT
-JDo7A6rYC+8tBhwhIPxiudMIaUVECUuf6ooTPDeXhzWTRcHgTN47imsBp26jbS5W
-BEGX/Hdz5a/3Rz3EJ39RJXemhbPaVNdNW/ehqswB1CVD7zxkxPs45qCTDDGARby+
-PjEgzFAKPwUVhmtmc9hFSripTXt/1KNl9z4ToIt+oDNSIHFk79luudqb/wZXErSH
-xJqJe6bxRAqsmFa62tDqYHdEUfCN8bNIXERtdIDlfQIDAQABMA0GCSqGSIb3DQEB
-CwUAA4ICAQAlQD+zX6whPyGujwzV+yx7GHlXpEJqVjS7SoVRiSdugtpmvTkVuG3a
-nejRUgntdlBFofJj5btwm6f7Eu2NvE0d2vopUZlkAnjtgVRFlpNguVVpuNyRMS5E
-uM+cqIjyJdhDGtU7iXZZ6xzL4alBhfVdRNRqdXzHvnKHjc5tSFAZN9/6ldRnmDxM
-nbaiPTFKxc45iDuXyY1Mh5V7bFWCS0GZVke1czgWtVRXPE1JN6ycv5YPbnT5o1D6
-9lWUIRTw36VxNfyGOsWQxtc9TJiRXru9VspE0y+VBjuVQdnKbdGk39RTfpZxNEgg
-X5hldAvExnW7dxZeFiXLGACXLhWoYqirFO8RAuvv367SJmXG1oOvt81VP2OZrpeJ
-p84unsHw4N1pVo7v25Qz60ECB/nLbIfCcWozlHw7pJnMeRvvsTB8O84Gq9OMytAF
-6/ZH0NiHgC6UrwZLoUtd7gty6sInqzqX4LMHqV0boeS+pj2Guh4/eGWE9lMTDb1P
-dyupkNAIm2h4hhoiWqae/BHn07S4k9PfMcog8YpmUlSvr1BGmMhIrbGEbw7M/qSh
-KwtTvM/pR0uc/2ifU4afsSzP8n7BgvhqG3AS86pFjxcUUQaTqycBHJGadOuxdGWO
-iFamIylTKTHaJyP0fcxpIK5x5/vsxC01UKqiU7lDUDTg2Ie2LSJK9g==
------END CERTIFICATE-----`)
+ [req]
+ default_bits  = 2048
+ distinguished_name = req_distinguished_name
+ req_extensions = req_ext
+ x509_extensions = v3_req
+ prompt = no
+
+ [req_distinguished_name]
+ countryName = XX
+ stateOrProvinceName = N/A
+ localityName = N/A
+ organizationName = Self-signed certificate
+ commonName = 120.0.0.1: Self-signed certificate
+
+ [req_ext]
+ subjectAltName = @alt_names
+
+ [v3_req]
+ subjectAltName = @alt_names
+
+ [alt_names]
+ IP.1 = 127.0.0.1
+*/
+var privateKey = []byte(`
+-----BEGIN PRIVATE KEY-----
+MIIEwAIBADANBgkqhkiG9w0BAQEFAASCBKowggSmAgEAAoIBAQDM4VDk2UICdib7
+b+TNb7KVhRElr9392ecD7ICCYRJgycPr7y3r12JVr0nrq2+Cwp7jMaUiT1Ad9gOk
+6U+uzS+T364eg3G7wi3E5oQ8CH/7YJKrrP59e//osMJRN4+NPvxDWs51RhLHIKb5
+x2zgHfcohkvCk2TRYHG3yaRRjmoh/VYZkYPVHO7s7zR/7rpcv2i/df4By+CgKITl
+tMfUtY5d+lyEqZnIJmsgT/iRTZI4g7QuyGCqmwfqy/wB3JWQ90Uaz11jX7ywp4wz
+PVOWg6F6X0KbMK1wyo401qoPy7idM56En0L39d10vOmjb5cEzbnCtI2yCXVN9fkR
+5e3N5Yc5AgMBAAECggEBAL/sEatPGdbUd4/yMZOAnvoRvQ5gwMOb7Bxw37FC3cRt
+PWs2kv3qteMuYUCzR7JmPhD14ItTYOmwG5nQNSS6cWdEkgdjepc4P0fD6PuTus/w
+l3TaiUtjbUa8zkrmkULvTcCKv/x7t/txSvmRJxyK9YywwSd0i2zXu68+5P7BOgq7
+Z8itU636NCQhzG7hESoiPZHDV71AiKc5jOL+xbmO1RGcaoSHlrVBNnzJo8XmYCyD
+4Fiq7ggPus0wcfC0D6dQizcb2RjJRRvCwuVdYYGNF76tF9MRI1kTvcb2lKURlrWc
+LLlmE3QiByzEKiffa9pVyZDzGiqvc/T7w05OfJd6WAECgYEA+dwiQFbG50HOyzFM
+5gm9ofuzsDghRNzriR7gxhkNW4DYi+ARA+sHMVsXrz6s0r46PwemAK3yNb59ecTa
+2uD17U9Ki8yMY8SgXodarDdfjzfSncTtvQnimcqKRU4uaiMFXs7ti4yhj7DSUEEe
+NUV5KTdtX/Y88/bezc9rxLdCL/ECgYEA0eo3CO8ZgdZm/1raI85sKSiAJVqLj0D+
+c2r5d2PnHseTYvQMoRXu8GNXxn04CnUh+SMViXk7lyPJV3d+fe0NV38HljCrUynG
+3fmtpoI9pw99RX7BelV2gRSdAhjsYsvmLs6AfbtNYnQBuMInIh+qWUXWcbqw9L7F
+zeDLHJZPE8kCgYEA6YMLW7f+AmklXA9CQAdAfB+hioKazSHu2uLJzTnimu7q8qbB
+IDlKKp1ooDZiDD8ObpO2WBI5OHNED0akB0WRcWzWTZsoZaGBA3dajXLe0xmntB00
+1qRja7m3yhfMFxON1FJt/Sq8X28wzyJcmgrItnV/udyGkLba+dvtaxaeO/ECgYEA
+iR397xcHyVj8lIaLAWKgIk5zTnMTwHKLA2d4JvWaDe/9pWCXM035cwrhViWLSsFy
+fKPfOJp5Q2O77CeA9861rVar5P5Lmxop7ete8+oVTZ//izqeNUPIEc8eNDWFi492
+/1Iien6zsMDoMwCXwWF/y6qjxkxVtLk8yhuxcS3534kCgYEAxt/mKYR6okqbZdLk
+5uahQ6/cvKxYCcMp+D5Ob1OsWhfZUU/Y1OyJcF9y4pntUpWWOog74bE6nit47plx
+17dSQ/8SqucN31nijHQY9gGCxEYfQrexMPnvwO0QN5NqiI+gheyK8phMe/CUB0E3
+npwkFDpM7x5uAah3cknlJbWaPsk=
+-----END PRIVATE KEY-----
+`)
+
+var publicCrt = []byte(`
+-----BEGIN CERTIFICATE-----
+MIIDhjCCAm6gAwIBAgIJAJDnIxyW8o35MA0GCSqGSIb3DQEBCwUAMHgxCzAJBgNV
+BAYTAlhYMQwwCgYDVQQIDANOL0ExDDAKBgNVBAcMA04vQTEgMB4GA1UECgwXU2Vs
+Zi1zaWduZWQgY2VydGlmaWNhdGUxKzApBgNVBAMMIjEyMC4wLjAuMTogU2VsZi1z
+aWduZWQgY2VydGlmaWNhdGUwHhcNMjAxMTE5MTkwNTU3WhcNMjAxMjE5MTkwNTU3
+WjB4MQswCQYDVQQGEwJYWDEMMAoGA1UECAwDTi9BMQwwCgYDVQQHDANOL0ExIDAe
+BgNVBAoMF1NlbGYtc2lnbmVkIGNlcnRpZmljYXRlMSswKQYDVQQDDCIxMjAuMC4w
+LjE6IFNlbGYtc2lnbmVkIGNlcnRpZmljYXRlMIIBIjANBgkqhkiG9w0BAQEFAAOC
+AQ8AMIIBCgKCAQEAzOFQ5NlCAnYm+2/kzW+ylYURJa/d/dnnA+yAgmESYMnD6+8t
+69diVa9J66tvgsKe4zGlIk9QHfYDpOlPrs0vk9+uHoNxu8ItxOaEPAh/+2CSq6z+
+fXv/6LDCUTePjT78Q1rOdUYSxyCm+cds4B33KIZLwpNk0WBxt8mkUY5qIf1WGZGD
+1Rzu7O80f+66XL9ov3X+AcvgoCiE5bTH1LWOXfpchKmZyCZrIE/4kU2SOIO0Lshg
+qpsH6sv8AdyVkPdFGs9dY1+8sKeMMz1TloOhel9CmzCtcMqONNaqD8u4nTOehJ9C
+9/XddLzpo2+XBM25wrSNsgl1TfX5EeXtzeWHOQIDAQABoxMwETAPBgNVHREECDAG
+hwR/AAABMA0GCSqGSIb3DQEBCwUAA4IBAQBBZgfLSX+FPdevk4vakdGMPPtDJcN7
+OZzeSUcFF10lWiLu6TrD70Cp1iqn5f2pw8i77VHHjuix3uaiUG1g7EJVZiU94rdY
+4k9n1YzbbBu0kZjPLV/y78oEWFaw6nm7sQmCnYD9h5DiEvEkUdzH1txMBedvtIG6
+NKd1KurKAZDnAFH4x/pcq+G3AF740IrkgoGoTZm4W7fP2cxkx46m5iweNbm/Uf2B
+fzpJr8wA9qtf+uOXulQwPZ5mZRAbaroa3iEuvaN2Zr0tKEp34iTdLjb0JIyjclh/
+8nsHehEjG05lMiehmD8NQ1nClggVH9gIL7j2xj9HRWxrFwHuDEqAnA+Y
+-----END CERTIFICATE-----
+`)

--- a/operator/builtin/output/otlp/otlp.go
+++ b/operator/builtin/output/otlp/otlp.go
@@ -3,6 +3,7 @@ package otlp
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -170,10 +171,10 @@ func (o *OTLPOutput) handleResponse(res *http.Response) error {
 	if !(res.StatusCode >= 200 && res.StatusCode < 300) {
 		body, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			return errors.NewError("non-success status code", "", "status", string(res.StatusCode))
+			return errors.NewError("non-success status code", "", "status", fmt.Sprint(res.StatusCode))
 		} else {
 			res.Body.Close()
-			return errors.NewError("non-success status code", "", "status", string(res.StatusCode), "body", string(body))
+			return errors.NewError("non-success status code", "", "status", fmt.Sprint(res.StatusCode), "body", string(body))
 		}
 	}
 	res.Body.Close()


### PR DESCRIPTION
## Description of Changes

- Generate certificates with an IP san instead of the Common Name, which go deprecated support for in 1.15. 
- Fix `string -> fmt.Sprintf` that somehow didn't get merged last time we came across it

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
