### PR TITLE
Promote severity from parsed syslog messages

### DIFF
--- a/operator/helper/parser.go
+++ b/operator/helper/parser.go
@@ -71,8 +71,17 @@ type ParserOperator struct {
 	SeverityParser *SeverityParser
 }
 
-// ProcessWith will process an entry with a parser function.
+// ProcessWith will run ParseWith on the entry, then forward the entry on to the next operators.
 func (p *ParserOperator) ProcessWith(ctx context.Context, entry *entry.Entry, parse ParseFunction) error {
+	if err := p.ParseWith(ctx, entry, parse); err != nil {
+		return err
+	}
+	p.Write(ctx, entry)
+	return nil
+}
+
+// ParseWith will process an entry's field with a parser function.
+func (p *ParserOperator) ParseWith(ctx context.Context, entry *entry.Entry, parse ParseFunction) error {
 	// Short circuit if the "if" condition does not match
 	skip, err := p.Skip(ctx, entry)
 	if err != nil {
@@ -127,8 +136,6 @@ func (p *ParserOperator) ProcessWith(ctx context.Context, entry *entry.Entry, pa
 	if severityParseErr != nil {
 		return p.HandleEntryError(ctx, entry, errors.Wrap(severityParseErr, "severity parser"))
 	}
-
-	p.Write(ctx, entry)
 	return nil
 }
 


### PR DESCRIPTION
## Description of Changes

The `syslog_parser` operator did not promote the syslog severity up to the entry level even though syslog severity levels are standard and we can do that conversion automatically. This modifies the operator to do that. 

Notably, this adds the `ParseWith` method to parsers, which parses a field without forwarding it on to the next output. This lets us promote the severity between parsing and sending. We can't promote the severity inside the exported `ProcessWith` method because the `parse` function passed to it doesn't have access to the entry, and is meant to operate on the field level. 

Fixes #223 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
