### PR TITLE
Fix issue with duplicate logs when parsing is skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## Unreleased
+### Fixed
+- Issue where entries skipped by `if` would be output twice
+
 ## [0.13.3] - 2020-12-01
 ### Added
 - New operators `forward_output` and `forward_input` to easily send log entries between stanza instances.

--- a/operator/helper/parser.go
+++ b/operator/helper/parser.go
@@ -73,15 +73,6 @@ type ParserOperator struct {
 
 // ProcessWith will run ParseWith on the entry, then forward the entry on to the next operators.
 func (p *ParserOperator) ProcessWith(ctx context.Context, entry *entry.Entry, parse ParseFunction) error {
-	if err := p.ParseWith(ctx, entry, parse); err != nil {
-		return err
-	}
-	p.Write(ctx, entry)
-	return nil
-}
-
-// ParseWith will process an entry's field with a parser function.
-func (p *ParserOperator) ParseWith(ctx context.Context, entry *entry.Entry, parse ParseFunction) error {
 	// Short circuit if the "if" condition does not match
 	skip, err := p.Skip(ctx, entry)
 	if err != nil {
@@ -92,6 +83,15 @@ func (p *ParserOperator) ParseWith(ctx context.Context, entry *entry.Entry, pars
 		return nil
 	}
 
+	if err := p.ParseWith(ctx, entry, parse); err != nil {
+		return err
+	}
+	p.Write(ctx, entry)
+	return nil
+}
+
+// ParseWith will process an entry's field with a parser function.
+func (p *ParserOperator) ParseWith(ctx context.Context, entry *entry.Entry, parse ParseFunction) error {
 	value, ok := entry.Get(p.ParseFrom)
 	if !ok {
 		err := errors.NewError(


### PR DESCRIPTION
## Description of Changes

I noticed that when `if` evaulates to `false` (parsing is skipped), the unparsed log is outputted twice. Looks like the issue is that skipping was being evaluated in `ParseWith` rather than in `ProcessWith`, so when skipped, we'd call `p.Write`, but then we'd return and call `p.Write` again. The diff doesn't show this well, but the solution was just to move skip logic into `ProcessWith` rather than `ProcessWith`. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
