### PR TITLE
Flusher Timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.5] - 2020-12-08
+### Fixed
+- Issue where flushers would retry indefinitely
+
 ## [0.13.4] - 2020-12-07
 ### Added
 - Recombine operator to combine multiline logs after ingestion and parsing

--- a/operator/flusher/flusher.go
+++ b/operator/flusher/flusher.go
@@ -12,8 +12,8 @@ import (
 )
 
 // These are vars so they can be overridden in tests
-var maxRetryInterval = time.Second
-var maxElapsedTime = 5 * time.Second
+var maxRetryInterval = time.Minute
+var maxElapsedTime = time.Hour
 
 // Config holds the configuration to build a new flusher
 type Config struct {


### PR DESCRIPTION
## Description of Changes
Flushers will now give up on retries eventually, rather than loop indefinitely.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
