### PR TITLE
Fixes excludes processing in the file_input operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## Unreleased
+
+### Fixed
+- `file_input` exclude processing could result in extra exclusions
+
 ## [0.13.6] - 2020-12-23
 ### Added
 - Ability to customize `file_input`'s `fingerprint_size`

--- a/operator/builtin/input/file/file.go
+++ b/operator/builtin/input/file/file.go
@@ -171,13 +171,13 @@ func getMatches(includes, excludes []string) []string {
 		for _, match := range matches {
 			for _, exclude := range excludes {
 				if itMatches, _ := filepath.Match(exclude, match); itMatches {
-					break INCLUDE
+					continue INCLUDE
 				}
 			}
 
 			for _, existing := range all {
 				if existing == match {
-					break INCLUDE
+					continue INCLUDE
 				}
 			}
 

--- a/operator/builtin/input/file/file_test.go
+++ b/operator/builtin/input/file/file_test.go
@@ -1373,3 +1373,57 @@ func BenchmarkFileInput(b *testing.B) {
 		})
 	}
 }
+
+// TestExclude tests that a log file will be excluded if it matches the
+// glob specified in the operator.
+func TestExclude(t *testing.T) {
+	tempDir := testutil.NewTempDir(t)
+	paths := writeTempFiles(tempDir, []string{"include.log", "exclude.log"})
+
+	includes := []string{filepath.Join(tempDir, "*")}
+	excludes := []string{filepath.Join(tempDir, "*exclude.log")}
+
+	matches := getMatches(includes, excludes)
+	require.ElementsMatch(t, matches, paths[:1])
+}
+func TestExcludeEmpty(t *testing.T) {
+	tempDir := testutil.NewTempDir(t)
+	paths := writeTempFiles(tempDir, []string{"include.log", "exclude.log"})
+
+	includes := []string{filepath.Join(tempDir, "*")}
+	excludes := []string{}
+
+	matches := getMatches(includes, excludes)
+	require.ElementsMatch(t, matches, paths)
+}
+func TestExcludeMany(t *testing.T) {
+	tempDir := testutil.NewTempDir(t)
+	paths := writeTempFiles(tempDir, []string{"a1.log", "a2.log", "b1.log", "b2.log"})
+
+	includes := []string{filepath.Join(tempDir, "*")}
+	excludes := []string{filepath.Join(tempDir, "a*.log"), filepath.Join(tempDir, "*2.log")}
+
+	matches := getMatches(includes, excludes)
+	require.ElementsMatch(t, matches, paths[2:3])
+}
+func TestExcludeDuplicates(t *testing.T) {
+	tempDir := testutil.NewTempDir(t)
+	paths := writeTempFiles(tempDir, []string{"a1.log", "a2.log", "b1.log", "b2.log"})
+
+	includes := []string{filepath.Join(tempDir, "*1*"), filepath.Join(tempDir, "a*")}
+	excludes := []string{filepath.Join(tempDir, "a*.log"), filepath.Join(tempDir, "*2.log")}
+
+	matches := getMatches(includes, excludes)
+	require.ElementsMatch(t, matches, paths[2:3])
+}
+
+// writes file with the specified file names and returns their full paths in order
+func writeTempFiles(tempDir string, names []string) []string {
+	result := make([]string, 0, len(names))
+	for _, name := range names {
+		path := filepath.Join(tempDir, name)
+		ioutil.WriteFile(path, []byte(name), 0755)
+		result = append(result, path)
+	}
+	return result
+}


### PR DESCRIPTION
## Description of Changes

With the break in the include/exclude processing, some matches were not considered and incorrectly excluded.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
