### PR TITLE
Make proxy optional for k8s_metadata_decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## Unreleased
+
+### Fixed
+- `k8s_metadata_decorator` using a proxy causes internal API timeout
+
 ## [0.13.8] - 2020-12-30
 ### Fixed
 - `file_input` exclude processing could result in extra exclusions

--- a/docs/operators/k8s_metadata_decorator.md
+++ b/docs/operators/k8s_metadata_decorator.md
@@ -12,6 +12,7 @@ The `k8s_metadata_decorator` operator adds labels and annotations to the entry u
 | `pod_name_field`  | `pod_name`               | A [field](/docs/types/field.md) that contains the k8s pod name associated with the log entry                                                                                                                                             |
 | `cache_ttl`       | 10m                      | A [duration](/docs/types/duration.md) indicating the time it takes for a cached entry to expire                                                                                                                                          |
 | `timeout`         | 10s                      | A [duration](/docs/types/duration.md) indicating how long to wait for the API to respond before timing out                                                                                                                               |
+| `allow_proxy`     | false                    | A boolean enabling or disabling [proxy](https://github.com/observIQ/stanza/blob/master/docs/proxy.md) support for this operator |
 | `if`              |                          | An [expression](/docs/types/expression.md) that, when set, will be evaluated to determine whether this operator should be used for the given entry. This allows you to do easy conditional parsing without branching logic with routers. |
 
 ### Example Configurations

--- a/docs/operators/k8s_metadata_decorator.md
+++ b/docs/operators/k8s_metadata_decorator.md
@@ -12,7 +12,7 @@ The `k8s_metadata_decorator` operator adds labels and annotations to the entry u
 | `pod_name_field`  | `pod_name`               | A [field](/docs/types/field.md) that contains the k8s pod name associated with the log entry                                                                                                                                             |
 | `cache_ttl`       | 10m                      | A [duration](/docs/types/duration.md) indicating the time it takes for a cached entry to expire                                                                                                                                          |
 | `timeout`         | 10s                      | A [duration](/docs/types/duration.md) indicating how long to wait for the API to respond before timing out                                                                                                                               |
-| `allow_proxy`     | false                    | A boolean enabling or disabling [proxy](https://github.com/observIQ/stanza/blob/master/docs/proxy.md) support for this operator |
+| `allow_proxy`     | false                    | Controls whether or not the agent will take into account [proxy](https://github.com/observIQ/stanza/blob/master/docs/proxy.md) configuration when communicating with the k8s metadata api |
 | `if`              |                          | An [expression](/docs/types/expression.md) that, when set, will be evaluated to determine whether this operator should be used for the given entry. This allows you to do easy conditional parsing without branching logic with routers. |
 
 ### Example Configurations

--- a/operator/builtin/parser/syslog/syslog_test.go
+++ b/operator/builtin/parser/syslog/syslog_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestSyslogParser(t *testing.T) {
+	now := func() time.Time {
+		return time.Date(2020, 06, 16, 3, 31, 34, 525, time.UTC)
+	}
+
 	basicConfig := func() *SyslogParserConfig {
 		cfg := NewSyslogParserConfig("test_operator_id")
 		cfg.OutputIDs = []string{"fake"}
@@ -35,7 +39,7 @@ func TestSyslogParser(t *testing.T) {
 				return cfg
 			}(),
 			"<34>Jan 12 06:30:00 1.2.3.4 apache_server: test message",
-			time.Date(time.Now().Year(), 1, 12, 6, 30, 0, 0, time.UTC),
+			time.Date(now().Year(), 1, 12, 6, 30, 0, 0, time.UTC),
 			map[string]interface{}{
 				"appname":  "apache_server",
 				"facility": 4,
@@ -54,7 +58,7 @@ func TestSyslogParser(t *testing.T) {
 				return cfg
 			}(),
 			[]byte("<34>Jan 12 06:30:00 1.2.3.4 apache_server: test message"),
-			time.Date(time.Now().Year(), 1, 12, 6, 30, 0, 0, time.UTC),
+			time.Date(now().Year(), 1, 12, 6, 30, 0, 0, time.UTC),
 			map[string]interface{}{
 				"appname":  "apache_server",
 				"facility": 4,

--- a/operator/builtin/transformer/k8smetadata/k8s_metadata_decorator_test.go
+++ b/operator/builtin/transformer/k8smetadata/k8s_metadata_decorator_test.go
@@ -54,6 +54,7 @@ func TestK8sMetadataDecoratorBuildDefault(t *testing.T) {
 		namespaceField: entry.NewResourceField("k8s.namespace.name"),
 		cacheTTL:       10 * time.Minute,
 		timeout:        10 * time.Second,
+		allowProxy:     false,
 	}
 
 	ops, err := cfg.Build(testutil.NewBuildContext(t))


### PR DESCRIPTION
## Description of Changes

Added `allow_proxy` option (default: false) for enabling or disabling the use of a proxy for the k8s_metadata_decorator operator. 

Generally, you would not want to use a proxy for connections to the Kubernetes API, however, the Kubernetes client will use any proxy set at HTTP_PROXY or HTTPS_PROXY unless the proxy function is set.

This is a problem because the proxy is likely not inside the cluster, therefore it cannot forward requests to the internal Kubernetes APIs.

supporting docs:
- https://godoc.org/k8s.io/client-go/rest#Config
- https://golang.org/pkg/net/http/#ProxyFromEnvironment

More context here: resolves https://github.com/observIQ/stanza/issues/238


## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
