### PR TITLE
fix syslog parser test case

### DIFF
--- a/operator/builtin/parser/syslog/syslog_test.go
+++ b/operator/builtin/parser/syslog/syslog_test.go
@@ -12,10 +12,6 @@ import (
 )
 
 func TestSyslogParser(t *testing.T) {
-	now := func() time.Time {
-		return time.Date(2020, 06, 16, 3, 31, 34, 525, time.UTC)
-	}
-
 	basicConfig := func() *SyslogParserConfig {
 		cfg := NewSyslogParserConfig("test_operator_id")
 		cfg.OutputIDs = []string{"fake"}
@@ -39,7 +35,7 @@ func TestSyslogParser(t *testing.T) {
 				return cfg
 			}(),
 			"<34>Jan 12 06:30:00 1.2.3.4 apache_server: test message",
-			time.Date(now().Year(), 1, 12, 6, 30, 0, 0, time.UTC),
+			time.Date(time.Now().Year(), 1, 12, 6, 30, 0, 0, time.UTC),
 			map[string]interface{}{
 				"appname":  "apache_server",
 				"facility": 4,
@@ -58,7 +54,7 @@ func TestSyslogParser(t *testing.T) {
 				return cfg
 			}(),
 			[]byte("<34>Jan 12 06:30:00 1.2.3.4 apache_server: test message"),
-			time.Date(now().Year(), 1, 12, 6, 30, 0, 0, time.UTC),
+			time.Date(time.Now().Year(), 1, 12, 6, 30, 0, 0, time.UTC),
 			map[string]interface{}{
 				"appname":  "apache_server",
 				"facility": 4,


### PR DESCRIPTION
## Description of Changes

Updated the syslog parser test case TestSyslogParser time function. 

Error before
```
--- FAIL: TestSyslogParser (0.04s)
    --- FAIL: TestSyslogParser/RFC3164 (0.01s)
        syslog_test.go:149:
            	Error Trace:	syslog_test.go:149
            	Error:      	Not equal:
            	            	expected: time.Time{wall:0x0, ext:63714407400, loc:(*time.Location)(nil)}
            	            	actual  : time.Time{wall:0x0, ext:63746029800, loc:(*time.Location)(nil)}

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -2,3 +2,3 @@
            	            	  wall: (uint64) 0,
            	            	- ext: (int64) 63714407400,
            	            	+ ext: (int64) 63746029800,
            	            	  loc: (*time.Location)(<nil>)
            	Test:       	TestSyslogParser/RFC3164
    --- FAIL: TestSyslogParser/RFC3164Bytes (0.01s)
        syslog_test.go:149:
            	Error Trace:	syslog_test.go:149
            	Error:      	Not equal:
            	            	expected: time.Time{wall:0x0, ext:63714407400, loc:(*time.Location)(nil)}
            	            	actual  : time.Time{wall:0x0, ext:63746029800, loc:(*time.Location)(nil)}

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -2,3 +2,3 @@
            	            	  wall: (uint64) 0,
            	            	- ext: (int64) 63714407400,
            	            	+ ext: (int64) 63746029800,
            	            	  loc: (*time.Location)(<nil>)
            	Test:       	TestSyslogParser/RFC3164Bytes
FAIL
coverage: 72.6% of statements in ./...
FAIL	github.com/observiq/stanza/operator/builtin/parser/syslog	0.169s
FAIL
make[1]: *** [for-all] Error 1
make: *** [test-only] Error 2
```

Tests pass now.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
