### PR TITLE
Container image: tzdata package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir -p /stanza_home
 ENV STANZA_HOME=/stanza_home
 RUN echo "pipeline:\n" >> /stanza_home/config.yaml
 RUN apt-get update && apt-get install -y systemd ca-certificates
+RUN DEBIAN_FRONTEND="noninteractive" TZ="UTC" apt-get install tzdata
 
 COPY ./artifacts/stanza_linux_amd64 /stanza_home/stanza
 COPY ./artifacts/stanza-plugins.tar.gz /tmp/stanza-plugins.tar.gz


### PR DESCRIPTION
Added the `tzdata` package to the container build. This will allow [the location](https://github.com/observIQ/stanza/pull/241) parameter for timestamp parsing to be used for container deployments.

I set TZ=utc explicitly, because it seems like the image runs with UTC time by default anyway (even on systems set to non UTC). 

Without this package, the agent will returns "timezone not found" errors.

This package does exist, for embedding the timezone database: https://golang.org/pkg/time/tzdata/. 

## Description of Changes

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
