### PR TITLE
Resolve an issue where \r causes parsing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Issue where Syslog parser would fail if `\r` was in the message [PR248](https://github.com/observIQ/stanza/pull/248)
+
 ### Added
 - uri_parser operator for parsing [absolute uri, relative uri, and uri query strings](https://tools.ietf.org/html/rfc3986)
 - container image: added package [tzdata](https://github.com/observIQ/stanza/pull/245)


### PR DESCRIPTION
## Description of Changes

Sometimes \r will get mistaken for a carriage return, causing parsing errors

Raw syslog:
```
<125>1 2021-02-05T16:31:54.000Z api.localnet WebServer - - [system@444 key="value\\\rap"]
```
Error
```
{"level":"error","timestamp":"2021-02-12T17:46:51.364-0500","message":"Failed to process entry","operator_id":"$.5424 tcp.syslog_parser","operator_type":"syslog_parser","error":"expecting chars `]`, `\"`, and `\\` to be escaped within param value [col 91]","action":"send","entry":{"timestamp":"2021-02-12T17:46:51.364796-05:00","severity":0,"labels":{"log_type":"syslog","plugin_id":"5424 tcp"},"record":"<125>1 2021-02-05T16:31:54.000Z api.localnet WebServer - - [system@444 key=\"value\\\\\\rap\"]"}}
```
Output record
```
{
  "timestamp": "2021-02-12T17:46:51.364796-05:00",
  "severity": 0,
  "labels": {
    "log_type": "syslog",
    "plugin_id": "5424 tcp"
  },
  "record": "<125>1 2021-02-05T16:31:54.000Z api.localnet WebServer - - [system@444 key=\"value\\\\\\rap\"]"
}
```

After making this change, the same syslog message returns no errors and the record looks like this:
```
{
  "timestamp": "2021-02-05T16:31:54Z",
  "severity": 0,
  "labels": {
    "log_type": "syslog",
    "plugin_id": "5424 tcp"
  },
  "record": {
    "appname": "WebServer",
    "facility": 15,
    "hostname": "api.localnet",
    "priority": 125,
    "severity": 5,
    "structured_data": {
      "system@444": {
        "key": "value\\rap"
      }
    },
    "version": 1
  }
}
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
