### PR TITLE
update google cloud output to v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Added optional `location` parameter to Syslog operator [pr247](https://github.com/observIQ/stanza/pull/247)
+- Updated Google Cloud output version to v0.1.2 [pr250](https://github.com/observIQ/stanza/pull/250)
 
 ## [0.13.12] - 2020-01-26
 

--- a/cmd/stanza/go.mod
+++ b/cmd/stanza/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/observiq/stanza/operator/builtin/input/k8sevent v0.1.0
 	github.com/observiq/stanza/operator/builtin/input/windows v0.1.1
 	github.com/observiq/stanza/operator/builtin/output/elastic v0.1.0
-	github.com/observiq/stanza/operator/builtin/output/googlecloud v0.1.0
+	github.com/observiq/stanza/operator/builtin/output/googlecloud v0.1.2
 	github.com/observiq/stanza/operator/builtin/output/newrelic v0.1.0
 	github.com/observiq/stanza/operator/builtin/output/otlp v0.0.0
 	github.com/observiq/stanza/operator/builtin/parser/syslog v0.1.0


### PR DESCRIPTION
## Description of Changes

Updated go.mod to build stanza with the latest Google Cloud output operator. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
