### PR TITLE
set file permissions before starting service

### DIFF
--- a/scripts/unix-install.sh
+++ b/scripts/unix-install.sh
@@ -984,6 +984,12 @@ request_service_replacement()
   esac
 }
 
+# Set file permissiosn
+set_permissions()
+{
+    chown -R $service_user:$service_user $agent_home
+}
+
 # This will display the results of an installation
 display_results()
 {
@@ -1039,6 +1045,7 @@ main()
   setup_installation
   install_package
   generate_config
+  set_permissions
   install_service
   display_results
 }


### PR DESCRIPTION
## Description of Changes

When running the install with a non root user, stanza fails to run because it does not have write permission to stanza home. `set_permissions` will set the owner.
```
./unix-install.sh -u stanza
```

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
