### PR TITLE
Operator tcp input adjustable buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.15] - 2021-02-26
+- Same as 0.13.14, but released with [plugins v0.0.48](https://github.com/observIQ/stanza-plugins/releases/tag/v0.0.48)
+  - Adds TLS support to `vmware_vcenter` and `vmware_esxi`
+
 ## [0.13.14] - 2021-02-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Added optional `max_buffer_size` parameter to tcp input operator
+
 ## [0.13.15] - 2021-02-26
 - Same as 0.13.14, but released with [plugins v0.0.48](https://github.com/observIQ/stanza-plugins/releases/tag/v0.0.48)
   - Adds TLS support to `vmware_vcenter` and `vmware_esxi`

--- a/docs/operators/tcp_input.md
+++ b/docs/operators/tcp_input.md
@@ -8,7 +8,7 @@ The `tcp_input` operator listens for logs on one or more TCP connections. The op
 | ---               | ---              | ---                                                                               |
 | `id`              | `tcp_input`      | A unique identifier for the operator                                              |
 | `output`          | Next in pipeline | The connected operator(s) that will receive all outbound entries                  |
-| `max_buffer_size` | 1                | Max buffer size in megabytes between 1 and 10.                                    |
+| `max_buffer_size` | `1024kib`        | Maximum size of buffer that may be allocated while reading TCP input              |
 | `listen_address`  | required         | A listen address of the form `<ip>:<port>`                                        |
 | `tls`             |                  | An optional `TLS` configuration (see the TLS configuration section)               |
 | `write_to`        | $                | The record [field](/docs/types/field.md) written to when creating a new log entry |

--- a/docs/operators/tcp_input.md
+++ b/docs/operators/tcp_input.md
@@ -8,6 +8,7 @@ The `tcp_input` operator listens for logs on one or more TCP connections. The op
 | ---               | ---              | ---                                                                               |
 | `id`              | `tcp_input`      | A unique identifier for the operator                                              |
 | `output`          | Next in pipeline | The connected operator(s) that will receive all outbound entries                  |
+| `max_buffer_size` | 1                | Max buffer size in megabytes between 1 and 10.                                    |
 | `listen_address`  | required         | A listen address of the form `<ip>:<port>`                                        |
 | `tls`             |                  | An optional `TLS` configuration (see the TLS configuration section)               |
 | `write_to`        | $                | The record [field](/docs/types/field.md) written to when creating a new log entry |

--- a/operator/builtin/input/tcp/tcp.go
+++ b/operator/builtin/input/tcp/tcp.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-	// InitialBufferSize is the initial size used for buffering
+	// minBufferSize is the initial size used for buffering
 	// TCP input
-	InitialBufferSize = 64*1024
+	minBufferSize = 64*1024
 
 	// DefaultMaxBufferSize is the max buffer sized used
 	// if MaxBufferSize is not set
@@ -70,8 +70,8 @@ func (c TCPInputConfig) Build(context operator.BuildContext) ([]operator.Operato
 		c.MaxBufferSize = DefaultMaxBufferSize
 	}
 
-	if c.MaxBufferSize < InitialBufferSize {
-		return nil, fmt.Errorf("invalid value for parameter 'max_buffer_size', must be equal to or greater than %d bytes", InitialBufferSize)
+	if c.MaxBufferSize < minBufferSize {
+		return nil, fmt.Errorf("invalid value for parameter 'max_buffer_size', must be equal to or greater than %d bytes", minBufferSize)
 	}
 
 	if c.ListenAddress == "" {

--- a/operator/builtin/input/tcp/tcp.go
+++ b/operator/builtin/input/tcp/tcp.go
@@ -57,6 +57,8 @@ func (c TCPInputConfig) Build(context operator.BuildContext) ([]operator.Operato
 	if c.MaxBufferSize < 0 || c.MaxBufferSize > 10 {
 		return nil, fmt.Errorf("invalid value for parameter 'max_buffer_size', must be between 1 and 10")
 	} else if c.MaxBufferSize == 0 {
+		// default to 1MB in order to remain backwards compatible
+		// with existing plugins and configurations
 		c.MaxBufferSize = 1
 	}
 

--- a/operator/builtin/input/tcp/tcp_test.go
+++ b/operator/builtin/input/tcp/tcp_test.go
@@ -218,15 +218,7 @@ func TestBuild(t *testing.T) {
 		{
 			"buffer-size-valid-min",
 			TCPInputConfig{
-				MaxBufferSize: 1,
-				ListenAddress: "10.0.0.1:9000",
-			},
-			false,
-		},
-		{
-			"buffer-size-valid-max",
-			TCPInputConfig{
-				MaxBufferSize: 10,
+				MaxBufferSize: 65536,
 				ListenAddress: "10.0.0.1:9000",
 			},
 			false,
@@ -240,17 +232,9 @@ func TestBuild(t *testing.T) {
 			true,
 		},
 		{
-			"buffer-size-to-high",
-			TCPInputConfig{
-				MaxBufferSize: 11,
-				ListenAddress: "10.0.0.1:9000",
-			},
-			true,
-		},
-		{
 			"tls-disabled-with-keypair-set",
 			TCPInputConfig{
-				MaxBufferSize: 1,
+				MaxBufferSize: 65536,
 				ListenAddress: "10.0.0.1:9000",
 				TLS: TLSConfig{
 					Enable: false,
@@ -263,7 +247,7 @@ func TestBuild(t *testing.T) {
 		{
 			"tls-enabled-with-no-such-file-error",
 			TCPInputConfig{
-				MaxBufferSize: 1,
+				MaxBufferSize: 65536,
 				ListenAddress: "10.0.0.1:9000",
 				TLS: TLSConfig{
 					Enable: true,

--- a/operator/builtin/input/tcp/tcp_test.go
+++ b/operator/builtin/input/tcp/tcp_test.go
@@ -180,6 +180,117 @@ func tlsTCPInputTest(input []byte, expected []string) func(t *testing.T) {
 	}
 }
 
+func TestBuild(t *testing.T) {
+	cases := []struct {
+		name           string
+		inputRecord    TCPInputConfig
+		expectErr      bool
+	}{
+		{
+			"default-auto-address",
+			TCPInputConfig{
+				ListenAddress: ":0",
+			},
+			false,
+		},
+		{
+			"default-fixed-address",
+			TCPInputConfig{
+				ListenAddress: "10.0.0.1:0",
+			},
+			false,
+		},
+		{
+			"default-fixed-address-port",
+			TCPInputConfig{
+				ListenAddress: "10.0.0.1:9000",
+			},
+			false,
+		},
+		{
+			"buffer-size-valid-default",
+			TCPInputConfig{
+				MaxBufferSize: 0,
+				ListenAddress: "10.0.0.1:9000",
+			},
+			false,
+		},
+		{
+			"buffer-size-valid-min",
+			TCPInputConfig{
+				MaxBufferSize: 1,
+				ListenAddress: "10.0.0.1:9000",
+			},
+			false,
+		},
+		{
+			"buffer-size-valid-max",
+			TCPInputConfig{
+				MaxBufferSize: 10,
+				ListenAddress: "10.0.0.1:9000",
+			},
+			false,
+		},
+		{
+			"buffer-size-negative",
+			TCPInputConfig{
+				MaxBufferSize: -1,
+				ListenAddress: "10.0.0.1:9000",
+			},
+			true,
+		},
+		{
+			"buffer-size-to-high",
+			TCPInputConfig{
+				MaxBufferSize: 11,
+				ListenAddress: "10.0.0.1:9000",
+			},
+			true,
+		},
+		{
+			"tls-disabled-with-keypair-set",
+			TCPInputConfig{
+				MaxBufferSize: 1,
+				ListenAddress: "10.0.0.1:9000",
+				TLS: TLSConfig{
+					Enable: false,
+					Certificate: "/tmp/cert",
+					PrivateKey: "/tmp/key",
+				},
+			},
+			false,
+		},
+		{
+			"tls-enabled-with-no-such-file-error",
+			TCPInputConfig{
+				MaxBufferSize: 1,
+				ListenAddress: "10.0.0.1:9000",
+				TLS: TLSConfig{
+					Enable: true,
+					Certificate: "/tmp/cert/missing",
+					PrivateKey: "/tmp/key/missing",
+				},
+			},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := NewTCPInputConfig("test_id")
+			cfg.ListenAddress = tc.inputRecord.ListenAddress
+			cfg.MaxBufferSize = tc.inputRecord.MaxBufferSize
+			cfg.TLS = tc.inputRecord.TLS
+			_, err := cfg.Build(testutil.NewBuildContext(t))
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestTcpInput(t *testing.T) {
 	t.Run("Simple", tcpInputTest([]byte("message\n"), []string{"message"}))
 	t.Run("CarriageReturn", tcpInputTest([]byte("message\r\n"), []string{"message"}))


### PR DESCRIPTION
## Description of Changes

Added adjustable buffer size for TCP input operator. Defaults to 1MB, with a max size of 10MB. The default buffer is 64k. https://golang.org/pkg/bufio/#Scanner.Buffer

Added test cases for building the operator.

Resolves https://github.com/observIQ/stanza/issues/255

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
