### PR TITLE
use google output 0.1.3

### DIFF
--- a/cmd/stanza/go.mod
+++ b/cmd/stanza/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/kardianos/service v1.2.0
-	github.com/observiq/stanza v0.13.17
+	github.com/observiq/stanza v0.13.18
 	github.com/observiq/stanza/operator/builtin/input/k8sevent v0.1.0
 	github.com/observiq/stanza/operator/builtin/input/windows v0.1.1
 	github.com/observiq/stanza/operator/builtin/output/elastic v0.1.0

--- a/cmd/stanza/go.mod
+++ b/cmd/stanza/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/observiq/stanza/operator/builtin/input/k8sevent v0.1.0
 	github.com/observiq/stanza/operator/builtin/input/windows v0.1.1
 	github.com/observiq/stanza/operator/builtin/output/elastic v0.1.0
-	github.com/observiq/stanza/operator/builtin/output/googlecloud v0.1.2
+	github.com/observiq/stanza/operator/builtin/output/googlecloud v0.1.3
 	github.com/observiq/stanza/operator/builtin/output/newrelic v0.1.0
 	github.com/observiq/stanza/operator/builtin/output/otlp v0.0.0
 	github.com/observiq/stanza/operator/builtin/parser/syslog v0.1.0


### PR DESCRIPTION
## Description of Changes

Use latest Google output https://github.com/observIQ/stanza/releases/tag/operator%2Fbuiltin%2Foutput%2Fgooglecloud%2Fv0.1.3

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
