### PR TITLE
support float64 values as long as they are whole numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.19] - Unreleased
+
+### Added
+- Added float64 to Severity parser's supported types [PR 267](https://github.com/observIQ/stanza/issues/267)
+
 ## [0.13.18] - 2021-04-02
 
 ### Changed

--- a/operator/helper/severity.go
+++ b/operator/helper/severity.go
@@ -58,6 +58,15 @@ func (m severityMap) find(value interface{}) (entry.Severity, string, error) {
 			return severity, strV, nil
 		}
 		return entry.Default, strV, nil
+	case float64:
+		if v != float64(int(v)) {
+			return entry.Default, "", fmt.Errorf("type %T cannot be a severity unless it is a whole number", v)
+		}
+		strV := strconv.Itoa(int(v))
+		if severity, ok := m[strV]; ok {
+			return severity, strV, nil
+		}
+		return entry.Default, strV, nil
 	case string:
 		if severity, ok := m[strings.ToLower(v)]; ok {
 			return severity, v, nil

--- a/operator/helper/severity_test.go
+++ b/operator/helper/severity_test.go
@@ -121,6 +121,12 @@ func TestSeverityParser(t *testing.T) {
 			expected: entry.Error,
 		},
 		{
+			name:     "custom-float64",
+			sample:   float64(6),
+			mapping:  map[interface{}]interface{}{"error": 6},
+			expected: entry.Error,
+		},
+		{
 			name:     "mixed-list-string",
 			sample:   "ThiS Is BaD",
 			mapping:  map[interface{}]interface{}{"error": []interface{}{"NOOOOOOO", "this is bad", 1234}},


### PR DESCRIPTION
## Description of Changes

Resolves https://github.com/observIQ/stanza/issues/267. Context is in the issue report.

- added ability to parse float64 for severity, as long as it is a whole number (2, 5, 10, etc)
- added test case for float64 value that represents a whole number
- ensure float64 tests that are not whole numbers continue to fail (see test case `custom-level-list-unparseable`)

It is important to handle float64 values as any number in json will unmarshal as a float64 value. For example, this struct has an int `sev`, but when unmarshalling into map[string]interface{}, we get a float64.

https://play.golang.org/p/On8UOPGFQ9d
```
package main

import (
	"encoding/json"
	"fmt"
)

type Source struct {
	Sev int `json:"sev"`
}

func main() {
	source := Source{Sev: 6,}

	b, err := json.Marshal(source)
	if err != nil {
		panic(err)
	}
	fmt.Println(string(b))

	x := make(map[string]interface{})
	if err := json.Unmarshal(b, &x); err != nil {
		panic(err)
	}
	
	value := fmt.Sprintf("%T", x["sev"])
	fmt.Println(value)
}
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
