### PR TITLE
fix max_delay key in documentation

### DIFF
--- a/docs/types/buffer.md
+++ b/docs/types/buffer.md
@@ -18,7 +18,7 @@ Memory buffers are configured by setting the `type` field of the `buffer` block 
 | ---               | ---              | ---                                                                              |
 | `max_entries`     | `1048576` (2^20) | The maximum number of entries stored in the memory buffer                        |
 | `max_chunk_size`  | 1000             | The maximum number of entries that are read from the buffer by default           |
-| `max_chunk_delay` | 1s               | The maximum amount of time that a reader will wait to batch entries into a chunk |
+| `max_delay` | 1s               | The maximum amount of time that a reader will wait to batch entries into a chunk |
 
 Example:
 ```yaml
@@ -27,7 +27,7 @@ Example:
   buffer:
     type: memory
     max_entries: 10000
-    max_chunk_delay: 1s
+    max_delay: 1s
     max_chunk_size: 1000
 ```
 
@@ -53,7 +53,7 @@ Disk buffers are configured by setting the `type` field of the `buffer` block on
 | ---               | ---      | ---                                                                                                                                      |
 | `max_size`        | `4GiB`   | The maximum size of the disk buffer file in bytes. See [ByteSize](/docs/types/bytesize.md) for details on allowed values.                |
 | `max_chunk_size`  | 1000     | The maximum number of entries that are read from the buffer by default                                                                   |
-| `max_chunk_delay` | 1s       | The maximum amount of time that a reader will wait to batch entries into a chunk                                                         |
+| `max_delay` | 1s       | The maximum amount of time that a reader will wait to batch entries into a chunk                                                         |
 | `path`            | required | The path to the directory which will contain the disk buffer data                                                                        |
 | `sync`            | `true`   | Whether to open the database files with the O_SYNC flag. Disabling this improves performance, but relaxes guarantees about log delivery. |
 
@@ -66,6 +66,6 @@ Example:
     max_size: 10000000 # 10MB
     path: /tmp/stanza_buffer
     sync: true
-    max_chunk_delay: 1s
+    max_delay: 1s
     max_chunk_size: 1000
 ```


### PR DESCRIPTION
## Description of Changes

The buffer documentation has a typo in the max_delay key name. 

https://github.com/observIQ/stanza/blob/master/operator/buffer/memory.go
https://github.com/observIQ/stanza/blob/master/operator/buffer/disk.go

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
