### PR TITLE
Operator syslog handle symbols

### DIFF
--- a/operator/builtin/parser/syslog/syslog_test.go
+++ b/operator/builtin/parser/syslog/syslog_test.go
@@ -313,6 +313,21 @@ func TestHandleSymbols(t *testing.T) {
 			[]byte("basic\"quote"),
 		},
 		{
+			"real-newline",
+			[]byte("\n"),
+			[]byte("\n"),
+		},
+		{
+			"real-return",
+			[]byte("\r"),
+			[]byte("\r"),
+		},
+		{
+			"real-tab",
+			[]byte("\t"),
+			[]byte("\t"),
+		},
+		{
 			"symbol-new-line-escaped",
 			[]byte("DOMAIN\\nexus"),
 			[]byte("DOMAIN\\\\nexus"),

--- a/operator/builtin/parser/syslog/syslog_test.go
+++ b/operator/builtin/parser/syslog/syslog_test.go
@@ -240,6 +240,32 @@ func TestSyslogParser(t *testing.T) {
 			"info",
 		},
 		{
+			"RFC5424-escaped-quote",
+			func() *SyslogParserConfig {
+				cfg := basicConfig()
+				cfg.Protocol = "rfc5424"
+				return cfg
+			}(),
+			`<86>1 2015-08-05T21:58:59.693Z 192.168.2.132 SecureAuth0 23108 ID52020 [SecureAuth@27389 user="invalid user: \"null\""]`,
+			time.Date(2015, 8, 5, 21, 58, 59, 693000000, time.UTC),
+			map[string]interface{}{
+				"appname":  "SecureAuth0",
+				"facility": 10,
+				"hostname": "192.168.2.132",
+				"msg_id":   "ID52020",
+				"priority": 86,
+				"proc_id":  "23108",
+				"structured_data": map[string]map[string]string{
+					"SecureAuth@27389": {
+						"user": "invalid user: \"null\"",
+					},
+				},
+				"version": 1,
+			},
+			entry.Info,
+			"info",
+		},
+		{
 			"RFC5424LongSDName",
 			func() *SyslogParserConfig {
 				cfg := basicConfig()


### PR DESCRIPTION
## Description of Changes

Sometimes a syslog message with have a DOMAIN\username field, it reaches the syslog parser like this:
```
... user="observiq\\tom"] some message here
... user="observiq\\ron"] some message here
... user="observiq\\null"] some message here
```

[go-syslog](https://github.com/observIQ/go-syslog) will fail to parse log entries if these symbol characters are not escaped. 

- added handleSymbols() function that handles escaping these situations
- added test cases for handleSymbols, TestHandleSymbols
- added test cases to TestSyslogParser

Real symbols such as `\n`, `\t`, `\r` are not modified.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
