### PR TITLE
build and test with -mod=mod param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
+GOFLAGS=-mod=mod
 
 GIT_SHA=$(shell git rev-parse --short HEAD)
 


### PR DESCRIPTION
## Description of Changes

CI fails on my other PR because of 
```
go: github.com/observiq/stanza@v0.13.10 requires
	github.com/Azure/azure-event-hubs-go/v3@v3.3.7: missing go.sum entry; to add it:
	go mod download github.com/Azure/azure-event-hubs-go/v3
```

I believe this should fix it, see https://github.com/golang/go/issues/44129

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
