### PR TITLE
Operator azure event hub labels

### DIFF
--- a/docs/operators/azure_eventhub_input.md
+++ b/docs/operators/azure_eventhub_input.md
@@ -1,14 +1,14 @@
-## `azure_eventhub_input` operator
+## `azure_event_hub_input` operator
 
-The `azure_eventhub_input` operator reads logs from Azure Event Hub using [Azure's SDK](https://github.com/Azure/azure-event-hubs-go)
+The `azure_event_hub_input` operator reads logs from Azure Event Hub using [Azure's SDK](https://github.com/Azure/azure-event-hubs-go)
 
-The `azure_eventhub_input` operator will use the `EnqueuedTime` field of the event as the parsed entry's timestamp. If `EnqueuedTime` is not set, `azure_eventhub_input` will use `IoTHubEnqueuedTime` if it is set. All other fields are added to the entry's record.
+The `azure_event_hub_input` operator will use the `EnqueuedTime` field of the event as the parsed entry's timestamp. If `EnqueuedTime` is not set, `azure_event_hub_input` will use `IoTHubEnqueuedTime` if it is set. All other fields are added to the entry's record.
 
 ### Configuration Fields
 
 | Field               | Default                | Description                                                                                   |
 | ---                 | ---                    | ---                                                                                           |
-| `id`                | `azure_eventhub_input` | A unique identifier for the operator                                                          |
+| `id`                | `azure_event_hub_input` | A unique identifier for the operator                                                          |
 | `output`            | Next in pipeline       | The connected operator(s) that will receive all outbound entries                              |
 | `namespace`         | required               | The Event Hub Namespace                                                                       |
 | `name`              | required               | The Event Hub Name                                                                            |
@@ -26,7 +26,7 @@ The `azure_eventhub_input` operator will use the `EnqueuedTime` field of the eve
 Configuration:
 ```yaml
 pipeline:
-- type: azure_eventhub_input
+- type: azure_event_hub_input
   namespace: stanza
   name: devel
   group: Default

--- a/docs/operators/azure_eventhub_input.md
+++ b/docs/operators/azure_eventhub_input.md
@@ -16,6 +16,8 @@ The `azure_eventhub_input` operator will use the `EnqueuedTime` field of the eve
 | `connection_string` | required               | The Event Hub [connection string](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string) |
 | `prefetch_count`    | `1000`                 | Desired number of events to read at one time                                                  |
 | `start_at`          | `end`                  | At startup, where to start reading events. Options are `beginning` or `end`                   |
+| `labels`            | {}                     | A map of `key: value` labels to add to the entry's labels                                     |
+| `resource`          | {}                     | A map of `key: value` labels to add to the entry's resource                                   |
 
 ### Example Configurations
 

--- a/operator/builtin/input/azure/eventhub/event_hub.go
+++ b/operator/builtin/input/azure/eventhub/event_hub.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const operatorName = "azure_eventhub_input"
+const operatorName = "azure_event_hub_input"
 
 func init() {
 	operator.Register(operatorName, func() operator.Builder { return NewEventHubConfig("") })

--- a/operator/builtin/input/azure/eventhub/event_hub.go
+++ b/operator/builtin/input/azure/eventhub/event_hub.go
@@ -188,11 +188,19 @@ func (e *EventHubInput) startConsumer(ctx context.Context, partitionID string, h
 // handleEvents is the handler for hub.Receive.
 func (e *EventHubInput) handleEvent(ctx context.Context, event *azhub.Event) error {
 	e.wg.Add(1)
-	eventEntry, err := parseEvent(event)
+
+	// NewEntry wraps entry.New() and will attach labels and resources
+	entry, err := e.NewEntry(nil)
 	if err != nil {
 		return err
 	}
-	e.Write(ctx, eventEntry)
+
+	entry, err = parseEvent(event, entry)
+	if err != nil {
+		return err
+	}
+
+	e.Write(ctx, entry)
 	e.wg.Done()
 	return nil
 }

--- a/operator/builtin/input/azure/eventhub/parse.go
+++ b/operator/builtin/input/azure/eventhub/parse.go
@@ -10,9 +10,7 @@ import (
 )
 
 // parseEvent parses an Azure Event Hub event as an Entry.
-func parseEvent(event *azhub.Event) (*entry.Entry, error) {
-	e := entry.New()
-
+func parseEvent(event *azhub.Event, e *entry.Entry) (*entry.Entry, error) {
 	x, err := parse(event)
 	if err != nil {
 		return e, err

--- a/operator/builtin/input/azure/eventhub/parse_test.go
+++ b/operator/builtin/input/azure/eventhub/parse_test.go
@@ -102,7 +102,7 @@ func TestParseEvent(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			e, err := parseEvent(tc.inputRecord)
+			e, err := parseEvent(tc.inputRecord, entry.New())
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedRecord, e)
 		})
@@ -387,7 +387,7 @@ func TestPromoteTime(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			e, err := parseEvent(tc.inputRecord)
+			e, err := parseEvent(tc.inputRecord, entry.New())
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedRecord, e)
 		})


### PR DESCRIPTION
## Description of Changes

Added labels + resources to Azure Event Hub input operator
```json
{
  "timestamp": "2021-04-23T18:07:50.66Z",
  "severity": 0,
  "labels": {
    "log_type": "azure_eventhub",
    "plugin_id": "azure_eventhub"
  },
  "record": {
    "data": "hello, world!",
    "id": "34c17068-5e26-45a5-8f62-2e7a47887097",
    "system_properties": {
      "x-opt-enqueued-time": "2021-04-23T18:07:50.66Z",
      "x-opt-offset": 39272,
      "x-opt-sequence-number": 12
    }
  }
}
```

Renamed azure_eventhub_input to azure_event_hub_input.

These changes will merge to the operator-azure-event-hub branch, which was already approved. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
