### PR TITLE
Trigger performance test with utf8 as default encoding

### DIFF
--- a/operator/builtin/input/file/config.go
+++ b/operator/builtin/input/file/config.go
@@ -165,7 +165,7 @@ var encodingOverrides = map[string]encoding.Encoding{
 	"ascii":    unicode.UTF8,
 	"us-ascii": unicode.UTF8,
 	"nop":      encoding.Nop,
-	"":         encoding.Nop,
+	"":         unicode.UTF8,
 }
 
 func lookupEncoding(enc string) (encoding.Encoding, error) {


### PR DESCRIPTION
**Do Not Merge**

This is a performance benchmark only.