### PR TITLE
Tcp udp labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - Unreleased
+
+### Added
+- Added optional network metadata labels to tcp / udp operators [PR302](https://github.com/observIQ/stanza/pull/302)
+
 ## [0.14.0] - 2021-05-07
 
 ### Added

--- a/docs/operators/tcp_input.md
+++ b/docs/operators/tcp_input.md
@@ -14,6 +14,7 @@ The `tcp_input` operator listens for logs on one or more TCP connections. The op
 | `write_to`        | $                | The record [field](/docs/types/field.md) written to when creating a new log entry |
 | `labels`          | {}               | A map of `key: value` labels to add to the entry's labels                         |
 | `resource`        | {}               | A map of `key: value` labels to add to the entry's resource                       |
+| `add_labels`      | false            | Adds `net.transport`, `net.peer.ip`, `net.peer.port`, `net.host.ip` and `net.host.port` labels |
 
 #### TLS Configuration
 

--- a/docs/operators/udp_input.md
+++ b/docs/operators/udp_input.md
@@ -12,6 +12,7 @@ The `udp_input` operator listens for logs from UDP packets.
 | `write_to`        | $                | The record [field](/docs/types/field.md) written to when creating a new log entry |
 | `labels`          | {}               | A map of `key: value` labels to add to the entry's labels                         |
 | `resource`        | {}               | A map of `key: value` labels to add to the entry's resource                       |
+| `add_labels`      | false            | Adds `net.transport`, `net.peer.ip`, `net.peer.port`, `net.host.ip` and `net.host.port` labels |
 
 ### Example Configurations
 

--- a/operator/builtin/input/tcp/tcp_test.go
+++ b/operator/builtin/input/tcp/tcp_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"net"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -99,6 +100,66 @@ func tcpInputTest(input []byte, expected []string) func(t *testing.T) {
 			select {
 			case entry := <-entryChan:
 				require.Equal(t, expectedMessage, entry.Record)
+			case <-time.After(time.Second):
+				require.FailNow(t, "Timed out waiting for message to be written")
+			}
+		}
+
+		select {
+		case entry := <-entryChan:
+			require.FailNow(t, "Unexpected entry: %s", entry)
+		case <-time.After(100 * time.Millisecond):
+			return
+		}
+	}
+}
+
+func tcpInputLabelsTest(input []byte, expected []string) func(t *testing.T) {
+	return func(t *testing.T) {
+		cfg := NewTCPInputConfig("test_id")
+		cfg.ListenAddress = ":0"
+		cfg.AddLabels = true
+
+		ops, err := cfg.Build(testutil.NewBuildContext(t))
+		require.NoError(t, err)
+		op := ops[0]
+
+		mockOutput := testutil.Operator{}
+		tcpInput := op.(*TCPInput)
+		tcpInput.InputOperator.OutputOperators = []operator.Operator{&mockOutput}
+
+		entryChan := make(chan *entry.Entry, 1)
+		mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			entryChan <- args.Get(1).(*entry.Entry)
+		}).Return(nil)
+
+		err = tcpInput.Start()
+		require.NoError(t, err)
+		defer tcpInput.Stop()
+
+		conn, err := net.Dial("tcp", tcpInput.listener.Addr().String())
+		require.NoError(t, err)
+		defer conn.Close()
+
+		_, err = conn.Write(input)
+		require.NoError(t, err)
+
+		for _, expectedMessage := range expected {
+			select {
+			case entry := <-entryChan:
+				expectedLabels := map[string]string{
+					"net.transport": "IP.TCP",
+				}
+				if addr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+					expectedLabels["net.host.ip"] = addr.IP.String()
+					expectedLabels["net.host.port"] = strconv.FormatInt(int64(addr.Port), 10)
+				}
+				if addr, ok := conn.LocalAddr().(*net.TCPAddr); ok {
+					expectedLabels["net.peer.ip"] = addr.IP.String()
+					expectedLabels["net.peer.port"] = strconv.FormatInt(int64(addr.Port), 10)
+				}
+				require.Equal(t, expectedMessage, entry.Record)
+				require.Equal(t, expectedLabels, entry.Labels)
 			case <-time.After(time.Second):
 				require.FailNow(t, "Timed out waiting for message to be written")
 			}
@@ -278,6 +339,11 @@ func TestBuild(t *testing.T) {
 func TestTcpInput(t *testing.T) {
 	t.Run("Simple", tcpInputTest([]byte("message\n"), []string{"message"}))
 	t.Run("CarriageReturn", tcpInputTest([]byte("message\r\n"), []string{"message"}))
+}
+
+func TestTcpInputAattributes(t *testing.T) {
+	t.Run("Simple", tcpInputLabelsTest([]byte("message\n"), []string{"message"}))
+	t.Run("CarriageReturn", tcpInputLabelsTest([]byte("message\r\n"), []string{"message"}))
 }
 
 func TestTLSTcpInput(t *testing.T) {

--- a/operator/builtin/input/udp/udp_test.go
+++ b/operator/builtin/input/udp/udp_test.go
@@ -2,6 +2,7 @@ package udp
 
 import (
 	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -61,11 +62,82 @@ func udpInputTest(input []byte, expected []string) func(t *testing.T) {
 	}
 }
 
+func udpInputLabelsTest(input []byte, expected []string) func(t *testing.T) {
+	return func(t *testing.T) {
+		cfg := NewUDPInputConfig("test_input")
+		cfg.ListenAddress = ":0"
+		cfg.AddLabels = true
+
+		ops, err := cfg.Build(testutil.NewBuildContext(t))
+		require.NoError(t, err)
+		op := ops[0]
+
+		mockOutput := testutil.Operator{}
+		udpInput, ok := op.(*UDPInput)
+		require.True(t, ok)
+
+		udpInput.InputOperator.OutputOperators = []operator.Operator{&mockOutput}
+
+		entryChan := make(chan *entry.Entry, 1)
+		mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			entryChan <- args.Get(1).(*entry.Entry)
+		}).Return(nil)
+
+		err = udpInput.Start()
+		require.NoError(t, err)
+		defer udpInput.Stop()
+
+		conn, err := net.Dial("udp", udpInput.connection.LocalAddr().String())
+		require.NoError(t, err)
+		defer conn.Close()
+
+		_, err = conn.Write(input)
+		require.NoError(t, err)
+
+		for _, expectedRecord := range expected {
+			select {
+			case entry := <-entryChan:
+				expectedLabels := map[string]string{
+					"net.transport": "IP.UDP",
+				}
+				// LocalAddr for udpInput.connection is a server address
+				if addr, ok := udpInput.connection.LocalAddr().(*net.UDPAddr); ok {
+					expectedLabels["net.host.ip"] = addr.IP.String()
+					expectedLabels["net.host.port"] = strconv.FormatInt(int64(addr.Port), 10)
+				}
+				// LocalAddr for conn is a client (peer) address
+				if addr, ok := conn.LocalAddr().(*net.UDPAddr); ok {
+					expectedLabels["net.peer.ip"] = addr.IP.String()
+					expectedLabels["net.peer.port"] = strconv.FormatInt(int64(addr.Port), 10)
+				}
+				require.Equal(t, expectedRecord, entry.Record)
+				require.Equal(t, expectedLabels, entry.Labels)
+			case <-time.After(time.Second):
+				require.FailNow(t, "Timed out waiting for message to be written")
+			}
+		}
+
+		select {
+		case entry := <-entryChan:
+			require.FailNow(t, "Unexpected entry: %s", entry)
+		case <-time.After(100 * time.Millisecond):
+			return
+		}
+	}
+}
+
 func TestUDPInput(t *testing.T) {
 	t.Run("Simple", udpInputTest([]byte("message1"), []string{"message1"}))
 	t.Run("TrailingNewlines", udpInputTest([]byte("message1\n"), []string{"message1"}))
 	t.Run("TrailingCRNewlines", udpInputTest([]byte("message1\r\n"), []string{"message1"}))
 	t.Run("NewlineInMessage", udpInputTest([]byte("message1\nmessage2\n"), []string{"message1\nmessage2"}))
+}
+
+func TestUDPInputLabels(t *testing.T) {
+	t.Run("Simple", udpInputLabelsTest([]byte("message1"), []string{"message1"}))
+	t.Run("TrailingNewlines", udpInputLabelsTest([]byte("message1\n"), []string{"message1"}))
+	t.Run("TrailingCRNewlines", udpInputLabelsTest([]byte("message1\r\n"), []string{"message1"}))
+	t.Run("NewlineInMessage", udpInputLabelsTest([]byte("message1\nmessage2\n"), []string{"message1\nmessage2"}))
 }
 
 func BenchmarkUdpInput(b *testing.B) {


### PR DESCRIPTION
## Description of Changes

Ported opentelemetry-log-collection's TCP and UDP attributes to Stanza labels. These labels are optional and disabled by default

config
```yaml
pipeline:
- type: udp_input
  add_labels: true
  listen_address: 0.0.0.0:5141
  output: out
- type: tcp_input
  add_labels: true
  listen_address: 0.0.0.0:5140
  output: out
- type: stdout
  id: out
```
netcat
```bash
echo hi | nc localhost 5140
echo hi | nc -u localhost 5141
```
output
```json
{"level":"info","timestamp":"2021-05-18T15:15:40.521-0400","message":"Starting stanza agent"}
{"level":"info","timestamp":"2021-05-18T15:15:40.522-0400","message":"Stanza agent started"}
{
  "timestamp": "2021-05-18T15:15:42.266158-04:00",
  "severity": 0,
  "labels": {
    "net.host.ip": "::1",
    "net.host.port": "5140",
    "net.peer.ip": "::1",
    "net.peer.port": "50310",
    "net.transport": "IP.TCP"
  },
  "record": "hi"
}
{
  "timestamp": "2021-05-18T15:15:56.964956-04:00",
  "severity": 0,
  "labels": {
    "net.host.ip": "::",
    "net.host.port": "5141",
    "net.peer.ip": "::1",
    "net.peer.port": "60017",
    "net.transport": "IP.UDP"
  },
  "record": "hi"
}
```

Ported from: https://github.com/open-telemetry/opentelemetry-log-collection/pull/108
Resolves https://github.com/observIQ/stanza/issues/301

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
