### PR TITLE
add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "gomod"
+    directory: "/internal/tools"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Description of Changes

See https://github.com/open-telemetry/opentelemetry-log-collection/pull/102/files

This configuration assumes that we will have a go module in `/` and `/internal/tools`. Right now we use sub modules but this PR https://github.com/observIQ/stanza/pull/304 will change that.

I also intend to update `make install-tools` to behave like this https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/Makefile, which will add the `/internal/tools` module. 

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
