### PR TITLE
Check Google logging client pointer for nil before calling Close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Panic during shutdown when Google Cloud Output credential file not found [Issue 264](https://github.com/observIQ/stanza/issues/264)
+- Fixed panic during shutdown when Google Cloud Output credential file not found [Issue 264](https://github.com/observIQ/stanza/issues/264)
 
 ## [0.14.2] - 2021-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Panic during shutdown when Google Cloud Output credential file not found [Issue 264](https://github.com/observIQ/stanza/issues/264)
+
 ## [0.14.2] - 2021-05-24
 
 ### Changed

--- a/operator/builtin/output/googlecloud/google_cloud.go
+++ b/operator/builtin/output/googlecloud/google_cloud.go
@@ -195,7 +195,10 @@ func (g *GoogleCloudOutput) Stop() error {
 	if err := g.buffer.Close(); err != nil {
 		return err
 	}
-	return g.client.Close()
+	if g.client != nil {
+		return g.client.Close()
+	}
+	return nil
 }
 
 // Process processes an entry


### PR DESCRIPTION
## Description of Changes

Check if client pointer is not nil before calling Close(). If nil, just return.

Config:
```yaml
pipeline:
- type: google_cloud_output
  credentials_file: /invalid_path.json
```

1. checkout master
2. run agent
3. observe panic **after** "Stopping stanza agent" log
4. checkout `google-output-close-panic`
5. re-run stanza
6. observe clean shutdown when stanza fails to read the credential file

Resolves https://github.com/observIQ/stanza/issues/320

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
