### PR TITLE
Move unit64s to the top of declarations

### DIFF
--- a/operator/buffer/memory.go
+++ b/operator/buffer/memory.go
@@ -59,12 +59,12 @@ func (c MemoryBufferConfig) Build(context operator.BuildContext, pluginID string
 // at which point it saves the entries into a database. It provides no guarantees about
 // lost entries if shut down uncleanly.
 type MemoryBuffer struct {
+	entryID       uint64
 	db            database.Database
 	pluginID      string
 	buf           chan *entry.Entry
 	inFlight      map[uint64]*entry.Entry
 	inFlightMux   sync.Mutex
-	entryID       uint64
 	sem           *semaphore.Weighted
 	maxChunkDelay time.Duration
 	maxChunkSize  uint

--- a/operator/flusher/flusher.go
+++ b/operator/flusher/flusher.go
@@ -51,11 +51,11 @@ func (c *Config) Build(logger *zap.SugaredLogger) *Flusher {
 // Flusher is used to flush entries from a buffer concurrently. It handles max concurrency,
 // retry behavior, and cancellation.
 type Flusher struct {
+	chunkIDCounter uint64
 	ctx            context.Context
 	cancel         context.CancelFunc
 	sem            *semaphore.Weighted
 	wg             sync.WaitGroup
-	chunkIDCounter uint64
 	*zap.SugaredLogger
 }
 


### PR DESCRIPTION
## Description of Changes

This should fix alignment issues on arm (raspberrypi). See https://github.com/golang/go/issues/23345

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
