### PR TITLE
Fix problem where parser errors would result in duplicate calls to the next operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed panic during shutdown when Google Cloud Output credential file not found [Issue 264](https://github.com/observIQ/stanza/issues/264)
+- Fixed bug where logs can be duplicated when a parser has on_error=send [PR 330](https://github.com/observIQ/stanza/pull/330)
 
 ## [1.0.0] - 2021-05-27
 

--- a/operator/builtin/parser/csv/csv_test.go
+++ b/operator/builtin/parser/csv/csv_test.go
@@ -238,7 +238,7 @@ func TestParserCSVInvalidJSONInput(t *testing.T) {
 		entry := entry.New()
 		entry.Record = "{\"name\": \"stanza\"}"
 		err = op.Process(context.Background(), entry)
-		require.Nil(t, err, "parse error on line 1, column 1: bare \" in non-quoted-field")
+		require.Error(t, err, "parse error on line 1, column 1: bare \" in non-quoted-field")
 		fake.ExpectRecord(t, "{\"name\": \"stanza\"}")
 	})
 }

--- a/operator/helper/transformer.go
+++ b/operator/helper/transformer.go
@@ -96,7 +96,6 @@ func (t *TransformerOperator) HandleEntryError(ctx context.Context, entry *entry
 	t.Errorw("Failed to process entry", zap.Any("error", err), zap.Any("action", t.OnError), zap.Any("entry", entry))
 	if t.OnError == SendOnError {
 		t.Write(ctx, entry)
-		return nil
 	}
 	return err
 }

--- a/testutil/mocks.go
+++ b/testutil/mocks.go
@@ -89,3 +89,13 @@ func (f *FakeOutput) ExpectEntry(t testing.TB, expected *entry.Entry) {
 		require.FailNow(t, "Timed out waiting for entry")
 	}
 }
+
+// ExpectNoEntry expects that no entry will be received within the specified time
+func (f *FakeOutput) ExpectNoEntry(t testing.TB, timeout time.Duration) {
+	select {
+	case <-f.Received:
+		require.FailNow(t, "Should not have received entry")
+	case <-time.After(timeout):
+		return
+	}
+}


### PR DESCRIPTION
## Description of Changes
`Transformer.HandleEntryError` is responsible for the following:
1. Log that an error occurred
2. Send or Drop the entry which encountered the error
3. Return the error encountered

In theory, the responsibility of this method to return the error which it was given is a little odd. However, in practice it is a helpful way for callers to bail out. (`return t.HandleEntryError(..., err)`)

The method was incorrectly returning `nil` when `on_error=send`, which ultimately allowed some operators to continue execution on the entry and pass it along to the next operator. (even though it had already been passed along by `HandleEntryError`.

This PR clarifies the expectation that `on_error` does not affect whether or not an error is returned when encountered. `on_error` only affects whether or not the entry that caused the error is passed along or not.

Aside from preventing this bug, and reworking the associated expectations in test cases, there should be no effect from this change. The error is dropped when returned from `operator.Process`.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
