### PR TITLE
Windows event log errors returned by publisher.Open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.1.1 - 2021-06-21
+
+### Fixed
+- Log error returned by publisher.Open in `operator/builtin/input/windows/operator.go` [PR 334](https://github.com/observIQ/stanza/pull/334)
+
 ## 1.1.0 - 2021-06-18
 
 ### Added

--- a/operator/builtin/input/windows/operator.go
+++ b/operator/builtin/input/windows/operator.go
@@ -188,7 +188,7 @@ func (e *EventLogInput) processEvent(ctx context.Context, event Event) {
 
 	publisher := NewPublisher()
 	if err := publisher.Open(simpleEvent.Provider.Name); err != nil {
-		e.Errorf("Failed to open publisher: %s")
+		e.Errorf("Failed to open publisher: %s", err)
 		e.sendEvent(ctx, simpleEvent)
 		return
 	}


### PR DESCRIPTION
## Description of Changes

There is one spot in windows event where we do not log the error

This results in: `Failed to open publisher: %s"` when calls to `publisher.Open` return an error.
```
{"level":"error","ts":"2021-06-21T11:25:11.485-0700","msg":"Failed to open publisher: %s","operator_id":"$.9e96dcdf-012e-4636-8235-7c11f48e9966.application_event_input","operator_type":"windows_eventlog_input"}
```

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
