### PR TITLE
Nicer error when event metadata request fails

### DIFF
--- a/operator/builtin/input/windows/operator.go
+++ b/operator/builtin/input/windows/operator.go
@@ -188,7 +188,7 @@ func (e *EventLogInput) processEvent(ctx context.Context, event Event) {
 
 	publisher := NewPublisher()
 	if err := publisher.Open(simpleEvent.Provider.Name); err != nil {
-		e.Errorf("Failed to open publisher: %s", err)
+		e.Errorf("Failed to open publisher: %s: Submitting entry without further parsing", err)
 		e.sendEvent(ctx, simpleEvent)
 		return
 	}


### PR DESCRIPTION
## Description of Changes

Windows Events input has two stages
1. Read an event from event hub
2. Request metadata about the event from step one, from event hub

Sometimes step 2 fails. This can be reproduced on systems with old events and using `start_at: beginning`. 

This PR adds a nicer error when windows event fails but we still publish the message (without metadata). The current error can trick the user into thinking they are missing events due to operator failure.

Additional context: https://github.com/open-telemetry/opentelemetry-log-collection/issues/206

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
