### PR TITLE
Update k8s example

### DIFF
--- a/examples/k8s/daemonset/daemonset.yaml
+++ b/examples/k8s/daemonset/daemonset.yaml
@@ -7,7 +7,6 @@ metadata:
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
-# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
 metadata:
   name: stanza-metadata
   namespace: default
@@ -21,7 +20,7 @@ rules:
     verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: stanza-metadata
 roleRef:
@@ -41,10 +40,16 @@ apiVersion: v1
 data:
   config.yaml: |2-
     pipeline:
-      - type: kubernetes
+      - type: kubernetes_container
+        cluster_name: stanza_example
+        container_name: '*'
+        # avoid parsing stanza's log output
+        exclude:
+          - /var/log/containers/stanza-*_*-*.log
+        start_at: end
 
-      - type: file_output
-        path: /tmp/test.out
+      # watch stanza's output with 'kubectl logs -f <pod name> | jq .'
+      - type: stdout
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -63,8 +68,18 @@ spec:
       serviceAccountName: stanza-metadata
       containers:
         - name: stanza
+          # Production deployments should use an image tag other than latest
           image: observiq/stanza:latest
           imagePullPolicy: Always
+          # Override args in order to set database location
+          # to the database hostPath volume
+          args:
+            - --config
+            - /stanza_home/config.yaml
+            - --database
+            - /stanza_home/database/stanza.db
+            - --plugin_dir
+            - /stanza_home/plugins
           resources:
             limits:
               memory: "250Mi"
@@ -80,6 +95,9 @@ spec:
               name: varlog
             - mountPath: /var/lib/docker/containers
               name: dockerlogs
+            - mountPath: /stanza_home/database/
+              name: database
+              readOnly: false
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
       volumes:
@@ -92,3 +110,6 @@ spec:
         - name: config
           configMap:
             name: stanza-config
+        - name: database
+          hostPath:
+            path: /var/observiq-agent/database


### PR DESCRIPTION
## Description of Changes

- Switched to kubernetes_container plugin
- Use stdout and kubectl logs to view stanza output, instead of file_output inside the container
- Use persistent storage for offset database
- Switch to latest rbac api

This example can run onMminikube with zero configuration. 

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
