### PR TITLE
resolve gosec suggestion, use crypo package for randomness

### DIFF
--- a/operator/builtin/transformer/filter/filter_test.go
+++ b/operator/builtin/transformer/filter/filter_test.go
@@ -2,7 +2,8 @@ package filter
 
 import (
 	"context"
-	"math/rand"
+	"io"
+	"math/big"
 	"os"
 	"testing"
 
@@ -141,14 +142,21 @@ func TestFilterDropRatio(t *testing.T) {
 		},
 	}
 
+	nextIndex := 0
+	randos := []int64{250, 750}
+	randInt = func(io.Reader, *big.Int) (*big.Int, error) {
+		defer func() {
+			nextIndex = (nextIndex + 1) % len(randos)
+		}()
+		return big.NewInt(randos[nextIndex]), nil
+	}
+
 	for i := 1; i < 11; i++ {
-		rand.Seed(1)
 		err = filterOperator.Process(context.Background(), testEntry)
 		require.NoError(t, err)
 	}
 
 	for i := 1; i < 11; i++ {
-		rand.Seed(2)
 		err = filterOperator.Process(context.Background(), testEntry)
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
## Description of Changes

Resolves Gosec suggestion
```
[/home/jsirianni/go/src/github.com/observiq/stanza/operator/builtin/transformer/filter/filter.go:84] - G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
    83: 
  > 84: 	if !filtered || rand.Float64() > f.dropRatio {
    85: 		f.Write(ctx, entry)
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
