### PR TITLE
file input: optional file_name_resolved and file_path_resolved labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.6 - Unreleased
+
+### Added
+- File input: Added optional labels for resolved symlink file name and path [PR 364](https://github.com/observIQ/stanza/pull/364)
+
 ## 1.1.5 - 2021-07-15
 
 ### Changed

--- a/docs/operators/file_input.md
+++ b/docs/operators/file_input.md
@@ -16,6 +16,8 @@ The `file_input` operator reads logs from files. It will place the lines read in
 | `encoding`             | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options               |
 | `include_file_name`    | `true`           | Whether to add the file name as the label `file_name`                                                              |
 | `include_file_path`    | `false`          | Whether to add the file path as the label `file_path`                                                              |
+| `include_file_name_resolved`    | `false`          | Whether to add the file name after symlinks resolution as the label `file_name_resolved`                       |
+| `include_file_path_resolved`    | `false`          | Whether to add the file path after symlinks resolution as the label `file_path_resolved`                       |
 | `start_at`             | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
 | `fingerprint_size`     | `1kb`            | The number of bytes with which to identify a file. The first bytes in the file are used as the fingerprint. Decreasing this value at any point will cause existing fingerprints to forgotten, meaning that all files will be read from the beginning (one time). |
 | `max_log_size`         | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |

--- a/operator/builtin/input/file/config.go
+++ b/operator/builtin/input/file/config.go
@@ -22,15 +22,17 @@ const (
 // NewInputConfig creates a new input config with default values
 func NewInputConfig(operatorID string) *InputConfig {
 	return &InputConfig{
-		InputConfig:        helper.NewInputConfig(operatorID, "file_input"),
-		PollInterval:       helper.Duration{Duration: 200 * time.Millisecond},
-		IncludeFileName:    true,
-		IncludeFilePath:    false,
-		StartAt:            "end",
-		FingerprintSize:    defaultFingerprintSize,
-		MaxLogSize:         defaultMaxLogSize,
-		MaxConcurrentFiles: defaultMaxConcurrentFiles,
-		Encoding:           helper.NewEncodingConfig(),
+		InputConfig:             helper.NewInputConfig(operatorID, "file_input"),
+		PollInterval:            helper.Duration{Duration: 200 * time.Millisecond},
+		IncludeFileName:         true,
+		IncludeFilePath:         false,
+		IncludeFileNameResolved: false,
+		IncludeFilePathResolved: false,
+		StartAt:                 "end",
+		FingerprintSize:         defaultFingerprintSize,
+		MaxLogSize:              defaultMaxLogSize,
+		MaxConcurrentFiles:      defaultMaxConcurrentFiles,
+		Encoding:                helper.NewEncodingConfig(),
 	}
 }
 
@@ -41,15 +43,17 @@ type InputConfig struct {
 	Include []string `json:"include,omitempty" yaml:"include,omitempty"`
 	Exclude []string `json:"exclude,omitempty" yaml:"exclude,omitempty"`
 
-	PollInterval       helper.Duration        `json:"poll_interval,omitempty"        yaml:"poll_interval,omitempty"`
-	Multiline          helper.MultilineConfig `json:"multiline,omitempty"            yaml:"multiline,omitempty"`
-	IncludeFileName    bool                   `json:"include_file_name,omitempty"    yaml:"include_file_name,omitempty"`
-	IncludeFilePath    bool                   `json:"include_file_path,omitempty"    yaml:"include_file_path,omitempty"`
-	StartAt            string                 `json:"start_at,omitempty"             yaml:"start_at,omitempty"`
-	FingerprintSize    helper.ByteSize        `json:"fingerprint_size,omitempty"     yaml:"fingerprint_size,omitempty"`
-	MaxLogSize         helper.ByteSize        `json:"max_log_size,omitempty"         yaml:"max_log_size,omitempty"`
-	MaxConcurrentFiles int                    `json:"max_concurrent_files,omitempty" yaml:"max_concurrent_files,omitempty"`
-	Encoding           helper.EncodingConfig  `json:",inline,omitempty"              yaml:",inline,omitempty"`
+	PollInterval            helper.Duration        `json:"poll_interval,omitempty"               yaml:"poll_interval,omitempty"`
+	Multiline               helper.MultilineConfig `json:"multiline,omitempty"                   yaml:"multiline,omitempty"`
+	IncludeFileName         bool                   `json:"include_file_name,omitempty"           yaml:"include_file_name,omitempty"`
+	IncludeFilePath         bool                   `json:"include_file_path,omitempty"           yaml:"include_file_path,omitempty"`
+	IncludeFileNameResolved bool                   `json:"include_file_name_resolved,omitempty"  yaml:"include_file_name_resolved,omitempty"`
+	IncludeFilePathResolved bool                   `json:"include_file_path_resolved,omitempty"  yaml:"include_file_path_resolved,omitempty"`
+	StartAt                 string                 `json:"start_at,omitempty"                    yaml:"start_at,omitempty"`
+	FingerprintSize         helper.ByteSize        `json:"fingerprint_size,omitempty"            yaml:"fingerprint_size,omitempty"`
+	MaxLogSize              helper.ByteSize        `json:"max_log_size,omitempty"                yaml:"max_log_size,omitempty"`
+	MaxConcurrentFiles      int                    `json:"max_concurrent_files,omitempty"        yaml:"max_concurrent_files,omitempty"`
+	Encoding                helper.EncodingConfig  `json:",inline,omitempty"                     yaml:",inline,omitempty"`
 }
 
 // Build will build a file input operator from the supplied configuration
@@ -123,25 +127,37 @@ func (c InputConfig) Build(context operator.BuildContext) ([]operator.Operator, 
 		filePathField = entry.NewLabelField("file_path")
 	}
 
+	fileNameResolvedField := entry.NewNilField()
+	if c.IncludeFileNameResolved {
+		fileNameResolvedField = entry.NewLabelField("file_name_resolved")
+	}
+
+	filePathResolvedField := entry.NewNilField()
+	if c.IncludeFilePathResolved {
+		filePathResolvedField = entry.NewLabelField("file_path_resolved")
+	}
+
 	op := &InputOperator{
-		InputOperator:      inputOperator,
-		Include:            c.Include,
-		Exclude:            c.Exclude,
-		SplitFunc:          splitFunc,
-		PollInterval:       c.PollInterval.Raw(),
-		persist:            helper.NewScopedDBPersister(context.Database, c.ID()),
-		FilePathField:      filePathField,
-		FileNameField:      fileNameField,
-		startAtBeginning:   startAtBeginning,
-		queuedMatches:      make([]string, 0),
-		encoding:           encoding,
-		firstCheck:         true,
-		cancel:             func() {},
-		knownFiles:         make([]*Reader, 0, 10),
-		fingerprintSize:    int(c.FingerprintSize),
-		MaxLogSize:         int(c.MaxLogSize),
-		MaxConcurrentFiles: c.MaxConcurrentFiles,
-		SeenPaths:          make(map[string]struct{}, 100),
+		InputOperator:         inputOperator,
+		Include:               c.Include,
+		Exclude:               c.Exclude,
+		SplitFunc:             splitFunc,
+		PollInterval:          c.PollInterval.Raw(),
+		persist:               helper.NewScopedDBPersister(context.Database, c.ID()),
+		FilePathField:         filePathField,
+		FileNameField:         fileNameField,
+		FilePathResolvedField: filePathResolvedField,
+		FileNameResolvedField: fileNameResolvedField,
+		startAtBeginning:      startAtBeginning,
+		queuedMatches:         make([]string, 0),
+		encoding:              encoding,
+		firstCheck:            true,
+		cancel:                func() {},
+		knownFiles:            make([]*Reader, 0, 10),
+		fingerprintSize:       int(c.FingerprintSize),
+		MaxLogSize:            int(c.MaxLogSize),
+		MaxConcurrentFiles:    c.MaxConcurrentFiles,
+		SeenPaths:             make(map[string]struct{}, 100),
 	}
 
 	return []operator.Operator{op}, nil

--- a/operator/builtin/input/file/file.go
+++ b/operator/builtin/input/file/file.go
@@ -21,15 +21,17 @@ import (
 type InputOperator struct {
 	helper.InputOperator
 
-	Include            []string
-	Exclude            []string
-	FilePathField      entry.Field
-	FileNameField      entry.Field
-	PollInterval       time.Duration
-	SplitFunc          bufio.SplitFunc
-	MaxLogSize         int
-	MaxConcurrentFiles int
-	SeenPaths          map[string]struct{}
+	Include               []string
+	Exclude               []string
+	FilePathField         entry.Field
+	FileNameField         entry.Field
+	FilePathResolvedField entry.Field
+	FileNameResolvedField entry.Field
+	PollInterval          time.Duration
+	SplitFunc             bufio.SplitFunc
+	MaxLogSize            int
+	MaxConcurrentFiles    int
+	SeenPaths             map[string]struct{}
 
 	persist helper.Persister
 
@@ -299,7 +301,7 @@ func (f *InputOperator) newReader(file *os.File, fp *Fingerprint, firstCheck boo
 		if err != nil {
 			return nil, err
 		}
-		newReader.Path = file.Name()
+		newReader.fileLabels = f.resolveFileLabels(file.Name())
 		return newReader, nil
 	}
 


### PR DESCRIPTION
## Description of Changes

Add optional file_name_resolved and file_path_resolved labels to file input

Ported from OTEL: https://github.com/open-telemetry/opentelemetry-log-collection/pull/189/files

With new labels enabled
```json
{
  "timestamp": "2021-07-15T19:39:39.289773231-04:00",
  "severity": 0,
  "labels": {
    "file_name": "in-symlink.json",
    "file_name_resolved": "test.json",
    "file_path": "./log/in-symlink.json",
    "file_path_resolved": "/tmp/test.json"
  },
  "record": {
    "key-symlink": "value"
  }
}
{
  "timestamp": "2021-07-15T19:39:39.289788021-04:00",
  "severity": 0,
  "labels": {
    "file_name": "in.json",
    "file_name_resolved": "in.json",
    "file_path": "./log/in.json",
    "file_path_resolved": "/home/jsirianni/go/src/github.com/observiq/stanza/log/in.json"
  },
  "record": {
    "key": "value"
  }
}
```

Config
```yaml
pipeline:
- type: file_input
  include: 
  - ./log/in.json
  - ./log/in-symlink.json
  include_file_path: true
  include_file_name_resolved: true
  include_file_path_resolved: true
  start_at: beginning
- type: json_parser
- type: stdout
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
