### PR TITLE
Support CSV tab delimited data

### DIFF
--- a/docs/operators/csv_parser.md
+++ b/docs/operators/csv_parser.md
@@ -70,6 +70,7 @@ Configuration:
 - type: csv_parser
   parse_from: message
   header: 'id,severity,message'
+  header_delimiter: ","
   delimiter: "\t"
 ```
 

--- a/operator/builtin/parser/csv/csv_test.go
+++ b/operator/builtin/parser/csv/csv_test.go
@@ -182,6 +182,20 @@ func TestParserCSV(t *testing.T) {
 				"msg":  "started agent",
 			},
 		},
+		{
+			"tab-delimiter",
+			func(p *CSVParserConfig) {
+				p.Header = testHeader
+				p.HeaderDelimiter = ","
+				p.FieldDelimiter = "\t"
+			},
+			"stanza\tINFO\tstarted agent",
+			map[string]interface{}{
+				"name": "stanza",
+				"sev":  "INFO",
+				"msg":  "started agent",
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Description of Changes

Using a tab delimiter like (`\t`) has always been supported but would not woork due to this error:
```
missing header delimiter in header
```

This was resolved here https://github.com/observIQ/stanza/pull/370 but a doc update is required as the new `header_delimiter` configuration option is required when using tab delimited data with comma delimited header.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
