### PR TITLE
Example: Fix database location so it is persistent

### DIFF
--- a/examples/k8s/daemonset/daemonset.yaml
+++ b/examples/k8s/daemonset/daemonset.yaml
@@ -42,7 +42,6 @@ data:
     pipeline:
       - type: kubernetes_container
         cluster_name: stanza_example
-        container_name: '*'
         # avoid parsing stanza's log output
         exclude:
           - /var/log/containers/stanza-*_*-*.log
@@ -93,8 +92,6 @@ spec:
               subPath: config.yaml
             - mountPath: /var/log
               name: varlog
-            - mountPath: /var/lib/docker/containers
-              name: dockerlogs
             - mountPath: /stanza_home/database/
               name: database
               readOnly: false
@@ -104,9 +101,6 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        - name: dockerlogs
-          hostPath:
-            path: /var/lib/docker/containers
         - name: config
           configMap:
             name: stanza-config

--- a/examples/k8s/daemonset/daemonset.yaml
+++ b/examples/k8s/daemonset/daemonset.yaml
@@ -70,8 +70,9 @@ spec:
           # Production deployments should use an image tag other than latest
           image: observiq/stanza:latest
           imagePullPolicy: Always
-          # Override args in order to set database location
+          # Override entrypoint args in order to set database location
           # to the database hostPath volume
+          command: ["/stanza_home/stanza"]
           args:
             - --config
             - /stanza_home/config.yaml
@@ -92,6 +93,8 @@ spec:
               subPath: config.yaml
             - mountPath: /var/log
               name: varlog
+            - mountPath: /var/lib/docker/containers
+              name: dockerlogs
             - mountPath: /stanza_home/database/
               name: database
               readOnly: false
@@ -101,6 +104,9 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
+        - name: dockerlogs
+          hostPath:
+            path: /var/lib/docker/containers
         - name: config
           configMap:
             name: stanza-config

--- a/examples/k8s/daemonset/daemonset_gke.yaml
+++ b/examples/k8s/daemonset/daemonset_gke.yaml
@@ -1,0 +1,113 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: stanza-metadata
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: stanza-metadata
+  namespace: default
+rules:
+  - apiGroups: ["", "apps", "batch"]
+    resources:
+      - pods
+      - namespaces
+      - replicasets
+      - jobs
+    verbs: ["get", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: stanza-metadata
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: stanza-metadata
+subjects:
+  - kind: ServiceAccount
+    name: stanza-metadata
+    namespace: default
+---
+kind: ConfigMap
+metadata:
+  name: stanza-config
+  namespace: default
+apiVersion: v1
+data:
+  config.yaml: |2-
+    pipeline:
+      - type: kubernetes_container
+        cluster_name: stanza_gke
+        # avoid parsing stanza's log output
+        exclude:
+          - /var/log/containers/stanza-*_*-*.log
+        start_at: end
+
+      # https://github.com/observIQ/stanza/blob/master/docs/operators/google_cloud_output.md
+      # When Stanza is running on GKE, a project_id and credentials_file parameters are not required when
+      # the node pool as the "logging" scope enabled
+      - type: google_cloud_output
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: stanza
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      name: stanza
+  template:
+    metadata:
+      labels:
+        name: stanza
+    spec:
+      serviceAccountName: stanza-metadata
+      containers:
+        - name: stanza
+          # Production deployments should use an image tag other than latest
+          image: observiq/stanza:latest
+          imagePullPolicy: Always
+          # Override args in order to set database location
+          # to the database hostPath volume
+          args:
+            - --config
+            - /stanza_home/config.yaml
+            - --database
+            - /stanza_home/database/stanza.db
+            - --plugin_dir
+            - /stanza_home/plugins
+          resources:
+            # keeping limit and request the same gives stanza
+            # a higher QoS
+            limits:
+              memory: "500Mi"
+              cpu: 500m
+            requests:
+              memory: "500Mi"
+              cpu: 500m
+          volumeMounts:
+            - mountPath: /stanza_home/config.yaml
+              name: config
+              subPath: config.yaml
+            - mountPath: /var/log
+              name: varlog
+            - mountPath: /stanza_home/database/
+              name: database
+              readOnly: false
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 5
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: config
+          configMap:
+            name: stanza-config
+        - name: database
+          hostPath:
+            path: /var/observiq-agent/database

--- a/examples/k8s/daemonset/daemonset_gke.yaml
+++ b/examples/k8s/daemonset/daemonset_gke.yaml
@@ -72,8 +72,9 @@ spec:
           # Production deployments should use an image tag other than latest
           image: observiq/stanza:latest
           imagePullPolicy: Always
-          # Override args in order to set database location
+          # Override entrypoint args in order to set database location
           # to the database hostPath volume
+          command: ["/stanza_home/stanza"]
           args:
             - --config
             - /stanza_home/config.yaml
@@ -96,6 +97,8 @@ spec:
               subPath: config.yaml
             - mountPath: /var/log
               name: varlog
+            - mountPath: /var/lib/docker/containers
+              name: dockerlogs
             - mountPath: /stanza_home/database/
               name: database
               readOnly: false
@@ -105,6 +108,9 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
+        - name: dockerlogs
+          hostPath:
+            path: /var/lib/docker/containers
         - name: config
           configMap:
             name: stanza-config


### PR DESCRIPTION
## Description of Changes

- added /var/log/docker volume mount back. turns out it is required to follow the symlink when using docker runtime
- added command parameter, which is required when using custom args. when not set, args are ignored and the [default entrypoint is used](https://github.com/observIQ/stanza/blob/master/Dockerfile).
```
ENTRYPOINT /stanza_home/stanza \
  --config /stanza_home/config.yaml \
  --database /stanza_home/stanza.db \
  --plugin_dir /stanza_home/plugins
```

The fact that this worked well is because the config was written to the correct spot. The database, however, was not in /stanza_home/database, therefore it was not persisting between reboots.

You can test this on minikube and gke by:
```
kubectl exec -it ds/stanza bash
# ls /stanza_home/database/
stanza.db
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
