### PR TITLE
check if journald directory exists

### DIFF
--- a/operator/builtin/input/journald/journald.go
+++ b/operator/builtin/input/journald/journald.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strconv"
 	"sync"
@@ -68,6 +69,9 @@ func (c JournaldInputConfig) Build(buildContext operator.BuildContext) ([]operat
 
 	switch {
 	case c.Directory != nil:
+		if _, err := os.Stat(*c.Directory); os.IsNotExist(err) {
+			return nil, fmt.Errorf("invalid value '%s' for parameter 'directory', directory does not exist: %s", *c.Directory, err)
+		}
 		args = append(args, "--directory", *c.Directory)
 	case len(c.Files) > 0:
 		for _, file := range c.Files {


### PR DESCRIPTION
## Description of Changes

When journald input is given an invalid directory parameter, it will silently fail without error. When running journalctl manually, you get this
```
# journalctl -f --directory /fake
Failed to open /fake: No such file or directory
```

Because journalctl fails completely, we should check if the directory exists before attempting to start.

This change adds the check, and is only applied when the optional `directory` parameter is specified. When the directory exists, the agent starts normally. When the directory does not exist, stanza gives this error and fails to start:
```
{
  "level": "error",
  "timestamp": "2021-08-16T16:33:13.220Z",
  "message": "Failed to build agent",
  "error": "invalid value /fake for parameter directory, directory does not exist: stat /fake: no such file or directory"
}
```

Because journalctl fails instead of waiting for the directory to appear, I believe Stanza should as well.

Resolves https://github.com/observIQ/stanza/issues/378

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
