### PR TITLE
Linux arm64 Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
 
   test-linux-arm64:
     executor: golang
-    resource_class: arm.large
+    resource_class: arm.medium
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,6 @@ jobs:
             mkdir -p ~/.docker/cli-plugins
             curl -fL https://github.com/docker/buildx/releases/download/v0.6.1/buildx-v0.6.1.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
             chmod a+x ~/.docker/cli-plugins/docker-buildx
-            sudo apt-get install -y binfmt-support qemu-user-static
       - run:
           name: "Publish Release on Docker Hub"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,11 +102,21 @@ jobs:
           file: '**/coverage.txt'
 
   test-linux-arm64:
-    executor: golang
-    resource_class: arm.medium
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.large
 
     steps:
       - checkout
+      - run:
+          name: Download golang
+          command: curl -SL https://golang.org/dl/go1.16.3.linux-arm64.tar.gz -O
+      - run:
+          name: Extract golang
+          command: tar -C ~ -xzf go1.16.3.linux-arm64.tar.gz
+      - run:
+          name: Add Golang to Path
+          command: echo 'export PATH=~/go/bin:$PATH' >> $BASH_ENV
       - run:
           name: Run Unit Tests
           command: make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,8 @@ jobs:
             mkdir -p ~/.docker/cli-plugins
             curl -fL https://github.com/docker/buildx/releases/download/v0.6.1/buildx-v0.6.1.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
             chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx create --name stanza --use
+            docker buildx inspect --bootstrap
       - run:
           name: "Publish Release on Docker Hub"
           command: |
@@ -93,21 +95,11 @@ jobs:
             export DOCKER_CLI_EXPERIMENTAL=enabled
 
             docker buildx build \
-              --platform linux/amd64 \
-              --build-arg platform=linux_amd64 \
-              --tag observiq/stanza:${docker_tag} .
-
-            docker buildx build \
-              --platform linux/arm64 \
-              --build-arg platform=linux_arm64 \
-              --tag observiq/stanza:${docker_tag} .
-
-            docker tag observiq/stanza:${docker_tag} observiq/stanza:latest
-            docker push observiq/stanza:${docker_tag}
-            docker push observiq/stanza:latest
-
-
-
+              --platform linux/amd64,linux/arm64 \
+              --tag observiq/stanza:${docker_tag} \
+              --tag observiq/stanza:latest \
+              --push \
+              .
 
   test-linux:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,7 +400,7 @@ workflows:
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+.*/
-      - test-linux-amd64:
+      - test-linux-arm64:
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,8 +118,10 @@ jobs:
           name: Add Golang to Path
           command: echo 'export PATH=~/go/bin:$PATH' >> $BASH_ENV
       - run:
+          # call go vet and go test directly, as `make test` will attempt
+          # to run with GOOS=windows GOARCH=arm64, which is an invalid combination
           name: Run Unit Tests
-          command: make test
+          command: go vet ./... && go test -race -coverprofile coverage.txt -coverpkg ./... ./...
       - codecov/upload:
           file: '**/coverage.txt'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,6 +400,10 @@ workflows:
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+.*/
+      - test-linux-amd64:
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+.*/
       - test-macos:
           filters:
             tags:
@@ -421,6 +425,7 @@ workflows:
       - wait-for-validation:
           requires:
             - test-linux
+            - test-linux-arm64
             - test-macos
             - test-windows
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
       - run:
           name: "Configure Docker multi arch builds"
           command: |
+            mkdir -p ~/.docker/cli-plugins
             curl -fL https://github.com/docker/buildx/releases/download/v0.6.1/buildx-v0.6.1.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
             chmod a+x ~/.docker/cli-plugins/docker-buildx
             sudo apt-get install -y binfmt-support qemu-user-static
@@ -93,7 +94,7 @@ jobs:
 
             docker buildx build \
               --platform linux/amd64 \
-              --build-arg platform=linux_amd64
+              --build-arg platform=linux_amd64 \
               --tag observiq/stanza:${docker_tag} .
 
             docker buildx build \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ jobs:
           command: |
             docker_tag=$(echo ${CIRCLE_TAG} | cut -b2- )
             docker login -u ${DOCKER_HUB_USER} -p ${DOCKER_HUB_TOKEN}
+            export DOCKER_CLI_EXPERIMENTAL=enabled
 
             docker buildx build \
               --platform linux/amd64 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,13 +80,22 @@ jobs:
       - attach_workspace:
           at: ./artifacts
       - run:
+          name: "Configure Docker multi arch builds"
+          command: |
+            curl -fL https://github.com/docker/buildx/releases/download/v0.6.1/buildx-v0.6.1.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            sudo apt-get install -y binfmt-support qemu-user-static
+      - run:
           name: "Publish Release on Docker Hub"
           command: |
             docker_tag=$(echo ${CIRCLE_TAG} | cut -b2- )
-            docker build -t observiq/stanza:${docker_tag} .
             docker login -u ${DOCKER_HUB_USER} -p ${DOCKER_HUB_TOKEN}
-            docker push observiq/stanza:${docker_tag}
+
+            docker buildx build \
+              --platform linux/arm64/v8,linux/amd64 \ \
+              --tag observiq/stanza:${docker_tag} .
             docker tag observiq/stanza:${docker_tag} observiq/stanza:latest
+            docker push observiq/stanza:${docker_tag}
             docker push observiq/stanza:latest
 
   test-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,11 +92,21 @@ jobs:
             docker login -u ${DOCKER_HUB_USER} -p ${DOCKER_HUB_TOKEN}
 
             docker buildx build \
-              --platform linux/arm64/v8,linux/amd64 \ \
+              --platform linux/amd64 \
+              --build-arg platform=linux_amd64
               --tag observiq/stanza:${docker_tag} .
+
+            docker buildx build \
+              --platform linux/arm64 \
+              --build-arg platform=linux_arm64 \
+              --tag observiq/stanza:${docker_tag} .
+
             docker tag observiq/stanza:${docker_tag} observiq/stanza:latest
             docker push observiq/stanza:${docker_tag}
             docker push observiq/stanza:latest
+
+
+
 
   test-linux:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,18 @@ jobs:
       - codecov/upload:
           file: '**/coverage.txt'
 
+  test-linux-arm64:
+    executor: golang
+    resource_class: arm.large
+
+    steps:
+      - checkout
+      - run:
+          name: Run Unit Tests
+          command: make test
+      - codecov/upload:
+          file: '**/coverage.txt'
+
   test-macos:
     executor: mac
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,21 @@
-FROM gcr.io/observiq-container-images/stanza-base:v1.0.0
+FROM golang:1.16 as stage
 
-ARG  platform
+WORKDIR /stanza
+COPY . .
+RUN rm -rf artifacts/*
+RUN make build
+WORKDIR /stanza/artifacts
+# hack: "mv stanza_* stanza" gives an error because mv does not like '_*'
+RUN for f in stanza_*; do mv "$f" stanza; done
+#RUN mv ./artifacts/stanza_* ./artifacts/stanza
+
+FROM gcr.io/observiq-container-images/stanza-base:v1.0.0
 
 RUN mkdir -p /stanza_home
 ENV STANZA_HOME=/stanza_home
 RUN echo "pipeline:\n" >> /stanza_home/config.yaml
 
-COPY ./artifacts/stanza_${platform} /stanza_home/stanza
+COPY --from=stage /stanza/artifacts/stanza /stanza_home/stanza
 COPY ./artifacts/stanza-plugins.tar.gz /tmp/stanza-plugins.tar.gz
 RUN tar -zxvf /tmp/stanza-plugins.tar.gz -C /stanza_home/
 ENTRYPOINT /stanza_home/stanza \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN make build
 WORKDIR /stanza/artifacts
 # hack: "mv stanza_* stanza" gives an error because mv does not like '_*'
 RUN for f in stanza_*; do mv "$f" stanza; done
-#RUN mv ./artifacts/stanza_* ./artifacts/stanza
 
 FROM gcr.io/observiq-container-images/stanza-base:v1.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM ubuntu:bionic
 
+ARG  PLATFORM
+
 RUN mkdir -p /stanza_home
 ENV STANZA_HOME=/stanza_home
 RUN echo "pipeline:\n" >> /stanza_home/config.yaml
 RUN apt-get update && apt-get install -y systemd ca-certificates
 RUN DEBIAN_FRONTEND="noninteractive" TZ="UTC" apt-get install tzdata
 
-COPY ./artifacts/stanza_linux_amd64 /stanza_home/stanza
+COPY ./artifacts/stanza_${PLATFORM} /stanza_home/stanza
 COPY ./artifacts/stanza-plugins.tar.gz /tmp/stanza-plugins.tar.gz
 RUN tar -zxvf /tmp/stanza-plugins.tar.gz -C /stanza_home/
 ENTRYPOINT /stanza_home/stanza \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM gcr.io/observiq-container-images/stanza-base:v1.0.0
 
-ARG  PLATFORM
+ARG  platform
 
 RUN mkdir -p /stanza_home
 ENV STANZA_HOME=/stanza_home
 RUN echo "pipeline:\n" >> /stanza_home/config.yaml
 
-COPY ./artifacts/stanza_${PLATFORM} /stanza_home/stanza
+COPY ./artifacts/stanza_${platform} /stanza_home/stanza
 COPY ./artifacts/stanza-plugins.tar.gz /tmp/stanza-plugins.tar.gz
 RUN tar -zxvf /tmp/stanza-plugins.tar.gz -C /stanza_home/
 ENTRYPOINT /stanza_home/stanza \

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,10 @@ build-darwin-amd64:
 build-linux-amd64:
 	@GOOS=linux GOARCH=amd64 $(MAKE) build
 
+.PHONY: build-linux-arm64
+build-linux-arm64:
+	@GOOS=linux GOARCH=arm64 $(MAKE) build
+
 .PHONY: build-windows-amd64
 build-windows-amd64:
 	@GOOS=windows GOARCH=amd64 $(MAKE) build

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ install:
 	(cd ./cmd/stanza && CGO_ENABLED=0 go install .)
 
 .PHONY: build-all
-build-all: build-darwin-amd64 build-linux-amd64 build-windows-amd64
+build-all: build-darwin-amd64 build-linux-amd64 build-linux-arm64 build-windows-amd64
 
 .PHONY: build-darwin-amd64
 build-darwin-amd64:

--- a/cmd/stanza/version.go
+++ b/cmd/stanza/version.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"runtime"
+
 	"github.com/observiq/stanza/version"
 	"github.com/spf13/cobra"
 )
@@ -12,7 +15,7 @@ func NewVersionCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "Print the stanza version",
 		Run: func(_ *cobra.Command, _ []string) {
-			println(version.GetVersion())
+			fmt.Println(version.GetVersion(), runtime.GOOS, runtime.GOARCH)
 		},
 	}
 }


### PR DESCRIPTION
## Description of Changes

Add docker support for linux/ARM64
- added goos and goarch to version output
- use `buildx` plugin when building
- refactor docker commands into single docker command for build, tag, push

This will allow a single tag to be built for AMD64 and ARM64.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
