### PR TITLE
test millisecond

### DIFF
--- a/operator/helper/duration_test.go
+++ b/operator/helper/duration_test.go
@@ -16,6 +16,11 @@ func TestParseDuration(t *testing.T) {
 		expected Duration
 	}{
 		{
+			"simple mills",
+			`"1ms"`,
+			Duration{time.Millisecond},
+		},
+		{
 			"simple second",
 			`"1s"`,
 			Duration{time.Second},


### PR DESCRIPTION
## Description of Changes

Added a test case for ensuring ms values will be correctly interpreted:

Example, I will be updating journald plugin to support the optional `poll_interval` field, which takes a value such as:
```
- type: journald_input
  poll_interval: 100ms
  ...
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
