### PR TITLE
check for container.name and k8s.container.name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.1.8 - Unreleased
 
+### Fixed
+
+- Resolved an issue where log type is not set correctly when using kubernetes_container plugin and Google output [PR 392](https://github.com/observIQ/stanza/pull/392)
+
 ## 1.1.7 - 2021-08-19
 
 ### Added

--- a/operator/builtin/output/googlecloud/resource.go
+++ b/operator/builtin/output/googlecloud/resource.go
@@ -35,6 +35,11 @@ func detectResourceType(e *entry.Entry) string {
 		if hasResource("container.name", e) {
 			return "k8s_container"
 		}
+		if hasResource("k8s.container.name", e) {
+			e.Resource["container.name"] = e.Resource["k8s.container.name"]
+			delete(e.Resource, "k8s.container.name")
+			return "k8s_container"
+		}
 		return "k8s_pod"
 	}
 
@@ -77,6 +82,7 @@ func k8sContainerResource(e *entry.Entry) *mrpb.MonitoredResource {
 			"pod_name":       e.Resource["k8s.pod.name"],
 			"namespace_name": e.Resource["k8s.namespace.name"],
 			"cluster_name":   e.Resource["k8s.cluster.name"],
+
 			// TODO project id
 		},
 	}

--- a/operator/builtin/output/googlecloud/resource.go
+++ b/operator/builtin/output/googlecloud/resource.go
@@ -82,7 +82,6 @@ func k8sContainerResource(e *entry.Entry) *mrpb.MonitoredResource {
 			"pod_name":       e.Resource["k8s.pod.name"],
 			"namespace_name": e.Resource["k8s.namespace.name"],
 			"cluster_name":   e.Resource["k8s.cluster.name"],
-
 			// TODO project id
 		},
 	}


### PR DESCRIPTION
## Description of Changes

Resolves https://github.com/observIQ/stanza/issues/391

Now, the container name is set as the resource (server), and the correct log type is set (k8s_container):

<img width="687" alt="Screen Shot 2021-08-19 at 1 52 51 PM" src="https://user-images.githubusercontent.com/23043836/130119560-f74217b2-a8c8-4705-a1d1-70629e2c9934.png">

Resolving this issue with allow users with multi container pods to filter easier. When searing on the pod, they will get all containers within the pod. Now they can filter on pod and container name.

The operator expects to see `container.name`, so when `k8s.container.name` is present, set `container.name` and return "k8s_container". 
```
e.Resource["container.name"] = e.Resource["k8s.container.name"]
delete(e.Resource, "k8s.container.name")
```

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
