### PR TITLE
use stanza base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM ubuntu:bionic
+FROM gcr.io/observiq-container-images/stanza-base:v1.0.0
 
 RUN mkdir -p /stanza_home
 ENV STANZA_HOME=/stanza_home
 RUN echo "pipeline:\n" >> /stanza_home/config.yaml
-RUN apt-get update && apt-get install -y systemd ca-certificates
-RUN DEBIAN_FRONTEND="noninteractive" TZ="UTC" apt-get install tzdata
 
 COPY ./artifacts/stanza_linux_amd64 /stanza_home/stanza
 COPY ./artifacts/stanza-plugins.tar.gz /tmp/stanza-plugins.tar.gz


### PR DESCRIPTION
## Description of Changes

Switched to the [stanza-base-image](https://github.com/observIQ/stanza-base-image) for docker builds
- results in 100MB savings in image size
  - likely due to a more optimized use of `apt` (cleaning up cache, single layer for installing packages)
- pins package versions to prevent **old** versions from being installed, this happens sometimes if the repo has an issue
- faster builds as the base image is already built, less steps

Removed the apt steps as the [base image performs those steps](https://github.com/observIQ/stanza-base-image/blob/master/Dockerfile), the packages already exist.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
