### PR TITLE
Label regex persistence

### DIFF
--- a/operator/builtin/input/file/fingerprint.go
+++ b/operator/builtin/input/file/fingerprint.go
@@ -16,10 +16,6 @@ const minFingerprintSize = 16       // bytes
 type Fingerprint struct {
 	// FirstBytes represents the first N bytes of a file
 	FirstBytes []byte
-
-	// Labels is an optional map that contains entry labels
-	// added to every record from a given file
-	Labels map[string]string
 }
 
 // NewFingerprint creates a new fingerprint from an open file
@@ -34,8 +30,6 @@ func (f *InputOperator) NewFingerprint(file *os.File) (*Fingerprint, error) {
 	fp := &Fingerprint{
 		FirstBytes: buf[:n],
 	}
-
-	fp.Labels = make(map[string]string)
 
 	return fp, nil
 }


### PR DESCRIPTION
## Description of Changes

This PR is going to merge into `file-input-lables-regex` branch which is already approved.

- Move `fingerprint.Labels` to `Reader.HeaderLabels`
  - This seems like a more appropriate place considering the Reader type is what is written to the database (which includes the `Fingerprint` type)
- Add logic to ensure `Reader.HeaderLabels` are persisted to the database by adding a deep copy to the `Reader.Copy` method

## Motivation

On branch `file-input-label-regex`, everything is working except label persistence. When the agent is restarted, all new log entries are missing their HeaderLabels. This PR ensures header labels are persisted with the Reader.

## Results

1. Start agent with new --database file, agent reads to end, all entries have the correct header labels
2. Add new entry to input file, agent reads new entry with correct header labels
3. Stop agent
4. Start agent, agent does not read any entries as it is picking up where it left off
5. Add new entry to file while agent is running, new entry has correct header labels  

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
