### PR TITLE
Tls min version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - github.com/aws/aws-sdk-go [PR395](https://github.com/observIQ/stanza/pull/395)
   - golang.org/x/text  [PR386](https://github.com/observIQ/stanza/pull/386)
 - ARM64 Container Image: [PR381](https://github.com/observIQ/stanza/pull/381)
+- TCP Input: Minimum TLS version is now configurable: [PR 400](https://github.com/observIQ/stanza/pull/400)
 
 ## 1.1.8 - 2021-08-19
 

--- a/docs/operators/tcp_input.md
+++ b/docs/operators/tcp_input.md
@@ -25,6 +25,7 @@ The `tcp_input` operator supports TLS, disabled by default.
 | `enable`          | `false`          | Boolean value to enable or disable TLS    |
 | `certificate`     |                  | File path for the X509 certificate chain  |
 | `private_key`     |                  | File path for the X509 private key        |
+| `min_version`     | `1.0`            | Minimum TLS version to accept connections from, defaults [TLS 1.0](https://pkg.go.dev/crypto/tls#Config)
 
 
 ### Example Configurations
@@ -54,5 +55,76 @@ Generated entries:
 {
   "timestamp": "2020-04-30T12:10:17.657143-04:00",
   "record": "message2"
+}
+```
+
+### Example TLS Configurations
+
+#### Simple TLS
+
+Configuration:
+```yaml
+pipeline:
+- type: tcp_input
+  listen_address: 0.0.0.0:5000
+  tls:
+    enable: true
+    certificate: ./cert
+    private_key: ./key
+- type: stdout
+```
+
+Send a log:
+```bash
+echo sample message | openssl s_client -connect localhost:5000
+```
+
+Generated entry:
+```json
+{
+  "timestamp": "2021-08-20T19:53:56.905051345-04:00",
+  "severity": 0,
+  "record": "sample message"
+}
+```
+
+#### TLS 1.3
+
+Configuration:
+```yaml
+pipeline:
+- type: tcp_input
+  listen_address: 0.0.0.0:5000
+  tls:
+    enable: true
+    certificate: ./cert
+    private_key: ./key
+    min_version: 1.3
+- type: stdout
+```
+
+Send a log with the `-tls1_3` flag:
+```bash
+echo sample message | openssl s_client -tls1_3 -connect localhost:5000
+```
+
+Generated entry:
+```json
+{
+  "timestamp": "2021-08-20T19:53:56.905051345-04:00",
+  "severity": 0,
+  "record": "sample message"
+}
+```
+
+Try it a second time using a lower TLS version, such as `-tls1_2`, and it will fail:
+```json
+{
+  "level":"error",
+  "timestamp":"2021-08-20T19:56:38.108-0400",
+  "message":"Scanner error",
+  "operator_id":"$.tcp_input",
+  "operator_type":"tcp_input",
+  "error":"tls: client offered only unsupported versions: [303 302 301]"
 }
 ```

--- a/operator/builtin/input/tcp/tcp.go
+++ b/operator/builtin/input/tcp/tcp.go
@@ -178,6 +178,7 @@ func (t *TCPInput) configureListener() error {
 		return nil
 	}
 
+	// #nosec - User to specify tls minimum version
 	config := tls.Config{
 		Certificates: []tls.Certificate{t.tlsKeyPair},
 		MinVersion:   t.tlsMinVersion,

--- a/operator/builtin/input/tcp/tcp_test.go
+++ b/operator/builtin/input/tcp/tcp_test.go
@@ -306,6 +306,90 @@ func TestBuild(t *testing.T) {
 			false,
 		},
 		{
+			"tls-min-version-default",
+			TCPInputConfig{
+				MaxBufferSize: 65536,
+				ListenAddress: "10.0.0.1:9000",
+				TLS: TLSConfig{
+					Enable:      false,
+					Certificate: "/tmp/cert",
+					PrivateKey:  "/tmp/key",
+					MinVersion:  0,
+				},
+			},
+			false,
+		},
+		{
+			"tls-min-version-1.0",
+			TCPInputConfig{
+				MaxBufferSize: 65536,
+				ListenAddress: "10.0.0.1:9000",
+				TLS: TLSConfig{
+					Enable:      false,
+					Certificate: "/tmp/cert",
+					PrivateKey:  "/tmp/key",
+					MinVersion:  1.0,
+				},
+			},
+			false,
+		},
+		{
+			"tls-min-version-1.1",
+			TCPInputConfig{
+				MaxBufferSize: 65536,
+				ListenAddress: "10.0.0.1:9000",
+				TLS: TLSConfig{
+					Enable:      false,
+					Certificate: "/tmp/cert",
+					PrivateKey:  "/tmp/key",
+					MinVersion:  1.1,
+				},
+			},
+			false,
+		},
+		{
+			"tls-min-version-1.2",
+			TCPInputConfig{
+				MaxBufferSize: 65536,
+				ListenAddress: "10.0.0.1:9000",
+				TLS: TLSConfig{
+					Enable:      false,
+					Certificate: "/tmp/cert",
+					PrivateKey:  "/tmp/key",
+					MinVersion:  1.2,
+				},
+			},
+			false,
+		},
+		{
+			"tls-min-version-1.3",
+			TCPInputConfig{
+				MaxBufferSize: 65536,
+				ListenAddress: "10.0.0.1:9000",
+				TLS: TLSConfig{
+					Enable:      false,
+					Certificate: "/tmp/cert",
+					PrivateKey:  "/tmp/key",
+					MinVersion:  1.3,
+				},
+			},
+			false,
+		},
+		{
+			"tls-invalid-min-version-1.4",
+			TCPInputConfig{
+				MaxBufferSize: 65536,
+				ListenAddress: "10.0.0.1:9000",
+				TLS: TLSConfig{
+					Enable:      false,
+					Certificate: "/tmp/cert",
+					PrivateKey:  "/tmp/key",
+					MinVersion:  1.4,
+				},
+			},
+			true,
+		},
+		{
 			"tls-enabled-with-no-such-file-error",
 			TCPInputConfig{
 				MaxBufferSize: 65536,


### PR DESCRIPTION
## Description of Changes

Golang's crypto/tls defaults to a minimum version of tls 1.0. This allows any modern client to connect without issue. A restricted environment may require a minimum version of 1.2 or 1.3. This PR allows the user to specify a minimum supported version.

- Added `min_version` parameter for the tls configuration
- Documented TLS configuration

Resolves https://github.com/observIQ/stanza/issues/349

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
