### PR TITLE
set default start / stop timeout to 120 seconds (systemd)

### DIFF
--- a/scripts/unix-install.sh
+++ b/scripts/unix-install.sh
@@ -934,7 +934,7 @@ Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 WorkingDirectory=$agent_home
 ExecStart=$agent_binary --log_file $agent_log --database $agent_database
 SuccessExitStatus=143
-TimeoutSec=0
+TimeoutSec=120
 StandardOutput=null
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
## Description of Changes

Resolves https://github.com/observIQ/stanza/issues/258

By setting TimeoutSec to two minutes, systemd will give stanza up to 120 seconds to start or stop. The value of 0 allows stanza to hang forever if there is an issue starting or stopping. This prevent servers from shutting down.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
