### PR TITLE
Fix Multi Arch Container Image builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
             curl -fL https://github.com/docker/buildx/releases/download/v0.6.1/buildx-v0.6.1.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
             chmod a+x ~/.docker/cli-plugins/docker-buildx
             docker context create tls-environment
-            docker buildx create --name stanza --use
+            docker buildx create --name stanza --use tls-environment
             docker buildx inspect --bootstrap
       - run:
           name: "Build container image"
@@ -114,7 +114,7 @@ jobs:
             curl -fL https://github.com/docker/buildx/releases/download/v0.6.1/buildx-v0.6.1.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
             chmod a+x ~/.docker/cli-plugins/docker-buildx
             docker context create tls-environment
-            docker buildx create --name stanza --use
+            docker buildx create --name stanza --use tls-environment
             docker buildx inspect --bootstrap
       - run:
           name: "Publish Release on Docker Hub"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 orbs:
   win: circleci/windows@2.4.0
-  gcp-cli: circleci/gcp-cli@@2.2.0
+  gcp-cli: circleci/gcp-cli@2.2.0
   codecov: codecov/codecov@1.0.2
   pr-comment: benjlevesque/pr-comment@0.1.4
   docker-buildx: sensu/docker-buildx@1.1.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           command: docker buildx use docker-multiarch
       - run:
           name: "Build container image"
-          no_output_timeout: 30m
+          no_output_timeout: 45m
           command: |
             docker_tag=$(echo ${CIRCLE_TAG} | cut -b2- )
             docker login -u ${DOCKER_HUB_USER} -p ${DOCKER_HUB_TOKEN}
@@ -177,7 +177,7 @@ jobs:
           command: docker buildx use docker-multiarch
       - run:
           name: "Publish Release on Docker Hub"
-          no_output_timeout: 30m
+          no_output_timeout: 45m
           command: |
             docker_tag=$(echo ${CIRCLE_TAG} | cut -b2- )
             docker login -u ${DOCKER_HUB_USER} -p ${DOCKER_HUB_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
             export DOCKER_CLI_EXPERIMENTAL=enabled
 
             docker buildx build \
+              --progress=plain \
               --platform linux/amd64,linux/arm64 \
               --tag observiq/stanza:latest \
               .
@@ -180,6 +181,7 @@ jobs:
             export DOCKER_CLI_EXPERIMENTAL=enabled
 
             docker buildx build \
+              --progress=plain \
               --platform linux/amd64,linux/arm64 \
               --tag observiq/stanza:${docker_tag} \
               --tag observiq/stanza:latest \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,6 @@ jobs:
             docker buildx create --name stanza --use tls-environment
             docker buildx inspect --bootstrap
       - run:
-          name: Download Plugins Tarball
-          command: curl -fL https://github.com/observiq/stanza-plugins/releases/latest/download/stanza-plugins.tar.gz -o ./artifacts/stanza-plugins.tar.gz
-      - run:
           name: "Build container image"
           command: |
             docker_tag=$(echo ${CIRCLE_TAG} | cut -b2- )
@@ -116,9 +113,6 @@ jobs:
             docker context create tls-environment
             docker buildx create --name stanza --use tls-environment
             docker buildx inspect --bootstrap
-      - run:
-          name: Download Plugins Tarball
-          command: curl -fL https://github.com/observiq/stanza-plugins/releases/latest/download/stanza-plugins.tar.gz -o ./artifacts/stanza-plugins.tar.gz
       - run:
           name: "Publish Release on Docker Hub"
           command: |
@@ -476,6 +470,9 @@ workflows:
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+.*/
+          requires:
+            - build
+            - fetch-plugins
       - fetch-plugins:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,14 +44,6 @@ jobs:
       - attach_workspace:
           at: ./artifacts
       - run:
-          name: "Configure Docker experimental"
-          command: |
-            ssh remote-docker \<<EOF
-                sudo bash -c 'echo "{\"experimental\": true}" > /etc/docker/daemon.json'
-                sudo systemctl restart docker
-                sudo docker info
-            EOF
-      - run:
           name: "Configure Docker multi arch builds"
           command: |
             mkdir -p ~/.docker/cli-plugins
@@ -120,14 +112,6 @@ jobs:
           version: 19.03.14
       - attach_workspace:
           at: ./artifacts
-      - run:
-          name: "Configure Docker experimental"
-          command: |
-            ssh remote-docker \<<EOF
-                sudo bash -c 'echo "{\"experimental\": true}" > /etc/docker/daemon.json'
-                sudo systemctl restart docker
-                sudo docker info
-            EOF
       - run:
           name: "Configure Docker multi arch builds"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ orbs:
   gcp-cli: circleci/gcp-cli@1.8.4
   codecov: codecov/codecov@1.0.2
   pr-comment: benjlevesque/pr-comment@0.1.4
+  docker-buildx: sensu/docker-buildx@1.1.1
 
 executors:
   golang:
@@ -46,9 +47,6 @@ jobs:
       - run:
           name: "Configure Docker multi arch builds"
           command: |
-            mkdir -p ~/.docker/cli-plugins
-            curl -fL https://github.com/docker/buildx/releases/download/v0.6.1/buildx-v0.6.1.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
             docker context create tls-environment
             docker buildx create --name stanza --use tls-environment
             docker buildx inspect --bootstrap
@@ -115,9 +113,6 @@ jobs:
       - run:
           name: "Configure Docker multi arch builds"
           command: |
-            mkdir -p ~/.docker/cli-plugins
-            curl -fL https://github.com/docker/buildx/releases/download/v0.6.1/buildx-v0.6.1.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
             docker context create tls-environment
             docker buildx create --name stanza --use tls-environment
             docker buildx inspect --bootstrap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
           version: 19.03.14
       - attach_workspace:
           at: ./artifacts
+      - docker-buildx/install
       - run:
           name: "Configure Docker multi arch builds"
           command: |
@@ -107,6 +108,7 @@ jobs:
           version: 19.03.14
       - attach_workspace:
           at: ./artifacts
+      - docker-buildx/install
       - run:
           name: "Configure Docker multi arch builds"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ jobs:
             mkdir -p ~/.docker/cli-plugins
             curl -fL https://github.com/docker/buildx/releases/download/v0.6.1/buildx-v0.6.1.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
             chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker context create tls-environment
             docker buildx create --name stanza --use
             docker buildx inspect --bootstrap
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,34 @@ jobs:
           root: ./artifacts
           paths:
             - "*"
+  build-docker:
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: "Configure Docker multi arch builds"
+          command: |
+            mkdir -p ~/.docker/cli-plugins
+            curl -fL https://github.com/docker/buildx/releases/download/v0.6.1/buildx-v0.6.1.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker context create tls-environment
+            docker buildx create --name stanza --use
+            docker buildx inspect --bootstrap
+      - run:
+          name: "Build container image"
+          command: |
+            docker_tag=$(echo ${CIRCLE_TAG} | cut -b2- )
+            docker login -u ${DOCKER_HUB_USER} -p ${DOCKER_HUB_TOKEN}
+            export DOCKER_CLI_EXPERIMENTAL=enabled
+
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --tag observiq/stanza:latest \
+              .
 
   fetch-plugins:
     executor: golang
@@ -438,6 +466,10 @@ workflows:
             tags:
               only: /^v\d+\.\d+\.\d+.*/
       - build:
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+.*/
+      - build-docker:
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,18 @@ jobs:
       - image: circleci/buildpack-deps:stretch
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.14
       - attach_workspace:
           at: ./artifacts
+      - run:
+          name: "Configure Docker experimental"
+          command: |
+            ssh remote-docker \<<EOF
+                sudo bash -c 'echo "{\"experimental\": true}" > /etc/docker/daemon.json'
+                sudo systemctl restart docker
+                sudo docker info
+            EOF
       - run:
           name: "Configure Docker multi arch builds"
           command: |
@@ -107,9 +116,18 @@ jobs:
       - image: circleci/buildpack-deps:stretch
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.14
       - attach_workspace:
           at: ./artifacts
+      - run:
+          name: "Configure Docker experimental"
+          command: |
+            ssh remote-docker \<<EOF
+                sudo bash -c 'echo "{\"experimental\": true}" > /etc/docker/daemon.json'
+                sudo systemctl restart docker
+                sudo docker info
+            EOF
       - run:
           name: "Configure Docker multi arch builds"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,9 @@ jobs:
             docker buildx create --name stanza --use tls-environment
             docker buildx inspect --bootstrap
       - run:
+          name: Download Plugins Tarball
+          command: curl -fL https://github.com/observiq/stanza-plugins/releases/latest/download/stanza-plugins.tar.gz -o ./artifacts/stanza-plugins.tar.gz
+      - run:
           name: "Build container image"
           command: |
             docker_tag=$(echo ${CIRCLE_TAG} | cut -b2- )
@@ -116,6 +119,9 @@ jobs:
             docker context create tls-environment
             docker buildx create --name stanza --use tls-environment
             docker buildx inspect --bootstrap
+      - run:
+          name: Download Plugins Tarball
+          command: curl -fL https://github.com/observiq/stanza-plugins/releases/latest/download/stanza-plugins.tar.gz -o ./artifacts/stanza-plugins.tar.gz
       - run:
           name: "Publish Release on Docker Hub"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,9 @@ jobs:
           name: Enable experimental Docker features
           command: echo 'export DOCKER_CLI_EXPERIMENTAL="enabled"' >> $BASH_ENV
       - run:
+          name: Create Docker context
+          command: docker context create tls-environment
+      - run:
           name: Initialize Docker buildx
           command: docker buildx install
       - run:
@@ -141,6 +144,9 @@ jobs:
       - run:
           name: Enable experimental Docker features
           command: echo 'export DOCKER_CLI_EXPERIMENTAL="enabled"' >> $BASH_ENV
+      - run:
+          name: Create Docker context
+          command: docker context create tls-environment
       - run:
           name: Initialize Docker buildx
           command: docker buildx install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ orbs:
   gcp-cli: circleci/gcp-cli@2.2.0
   codecov: codecov/codecov@1.0.2
   pr-comment: benjlevesque/pr-comment@0.1.4
-  docker-buildx: sensu/docker-buildx@1.1.1
 
 executors:
   golang:
@@ -44,13 +43,38 @@ jobs:
           version: 19.03.14
       - attach_workspace:
           at: ./artifacts
-      - docker-buildx/install
       - run:
-          name: "Configure Docker multi arch builds"
+          name: Install Docker buildx
           command: |
-            docker context create tls-environment
-            docker buildx create --name stanza --use tls-environment
-            docker buildx inspect --bootstrap
+            mkdir -p ~/.docker/cli-plugins
+            curl -sSL -o ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.6.2/buildx-v0.6.2.linux-amd64
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+      - run:
+          name: Enable experimental Docker features
+          command: echo 'export DOCKER_CLI_EXPERIMENTAL="enabled"' >> $BASH_ENV
+      - run:
+          name: Initialize Docker buildx
+          command: docker buildx install
+      - run:
+          name: Start multiarch/qemu-user-static container
+          command: >
+            docker run --rm --privileged
+            multiarch/qemu-user-static:<< parameters.qemu-user-static-version >>
+            --reset -p yes
+      - run:
+          name: Remove buildx multiarch container in case it exists
+          command: docker rm -f buildx_buildkit_docker-multiarch0 || continue
+      - run:
+          name: Create docker-multiarch builder
+          command: >
+            docker buildx create --name docker-multiarch
+            --platform linux/386,linux/amd64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/arm64,linux/mips64le,linux/ppc64le,linux/riscv64,linux/s390x
+      - run:
+          name: Inspect & bootstrap docker-multiarch builder
+          command: docker buildx inspect --builder docker-multiarch --bootstrap
+      - run:
+          name: Set docker-multiarch as default builder
+          command: docker buildx use docker-multiarch
       - run:
           name: "Build container image"
           command: |
@@ -108,13 +132,38 @@ jobs:
           version: 19.03.14
       - attach_workspace:
           at: ./artifacts
-      - docker-buildx/install
       - run:
-          name: "Configure Docker multi arch builds"
+          name: Install Docker buildx
           command: |
-            docker context create tls-environment
-            docker buildx create --name stanza --use tls-environment
-            docker buildx inspect --bootstrap
+            mkdir -p ~/.docker/cli-plugins
+            curl -sSL -o ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.6.2/buildx-v0.6.2.linux-amd64
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+      - run:
+          name: Enable experimental Docker features
+          command: echo 'export DOCKER_CLI_EXPERIMENTAL="enabled"' >> $BASH_ENV
+      - run:
+          name: Initialize Docker buildx
+          command: docker buildx install
+      - run:
+          name: Start multiarch/qemu-user-static container
+          command: >
+            docker run --rm --privileged
+            multiarch/qemu-user-static:<< parameters.qemu-user-static-version >>
+            --reset -p yes
+      - run:
+          name: Remove buildx multiarch container in case it exists
+          command: docker rm -f buildx_buildkit_docker-multiarch0 || continue
+      - run:
+          name: Create docker-multiarch builder
+          command: >
+            docker buildx create --name docker-multiarch
+            --platform linux/386,linux/amd64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/arm64,linux/mips64le,linux/ppc64le,linux/riscv64,linux/s390x
+      - run:
+          name: Inspect & bootstrap docker-multiarch builder
+          command: docker buildx inspect --builder docker-multiarch --bootstrap
+      - run:
+          name: Set docker-multiarch as default builder
+          command: docker buildx use docker-multiarch
       - run:
           name: "Publish Release on Docker Hub"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -536,9 +536,10 @@ workflows:
               only: /^v\d+\.\d+\.\d+.*/
           requires:
             - build
-            - fetch-plugins
       - fetch-plugins:
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+.*/
       - wait-for-validation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ jobs:
           command: docker buildx use docker-multiarch
       - run:
           name: "Build container image"
+          no_output_timeout: 30m
           command: |
             docker_tag=$(echo ${CIRCLE_TAG} | cut -b2- )
             docker login -u ${DOCKER_HUB_USER} -p ${DOCKER_HUB_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           name: Start multiarch/qemu-user-static container
           command: >
             docker run --rm --privileged
-            multiarch/qemu-user-static:<< parameters.qemu-user-static-version >>
+            multiarch/qemu-user-static:5.2.0-2
             --reset -p yes
       - run:
           name: Remove buildx multiarch container in case it exists
@@ -148,7 +148,7 @@ jobs:
           name: Start multiarch/qemu-user-static container
           command: >
             docker run --rm --privileged
-            multiarch/qemu-user-static:<< parameters.qemu-user-static-version >>
+            multiarch/qemu-user-static:5.2.0-2
             --reset -p yes
       - run:
           name: Remove buildx multiarch container in case it exists

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,8 @@ jobs:
             ghr -t ${GHI_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/
 
   publish-docker-release:
-    resource_class: large
+    # building amd64 + arm64 is compute intensive
+    resource_class: 2xlarge
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:
@@ -175,6 +176,7 @@ jobs:
           command: docker buildx use docker-multiarch
       - run:
           name: "Publish Release on Docker Hub"
+          no_output_timeout: 30m
           command: |
             docker_tag=$(echo ${CIRCLE_TAG} | cut -b2- )
             docker login -u ${DOCKER_HUB_USER} -p ${DOCKER_HUB_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ jobs:
           command: GOPROXY=direct go get github.com/observiq/amazon-log-agent-benchmark-tool/cmd/logbench/ &&
             go build -o ./bin/logbench github.com/observiq/amazon-log-agent-benchmark-tool/cmd/logbench/
 
-      - gcp-cli/install
+      - gcp-cli/install:
           version: "354.0.0"
       - gcp-cli/initialize:
           gcloud-service-key: SERVICE_ACCOUNT

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 orbs:
   win: circleci/windows@2.4.0
-  gcp-cli: circleci/gcp-cli@1.8.4
+  gcp-cli: circleci/gcp-cli@@2.2.0
   codecov: codecov/codecov@1.0.2
   pr-comment: benjlevesque/pr-comment@0.1.4
   docker-buildx: sensu/docker-buildx@1.1.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,7 @@ jobs:
             go build -o ./bin/logbench github.com/observiq/amazon-log-agent-benchmark-tool/cmd/logbench/
 
       - gcp-cli/install
+          version: "354.0.0"
       - gcp-cli/initialize:
           gcloud-service-key: SERVICE_ACCOUNT
           google-project-id: PROJECT

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - run:
           name: Create docker-multiarch builder
           command: >
-            docker buildx create --name docker-multiarch
+            docker buildx create --name docker-multiarch tls-environment
             --platform linux/386,linux/amd64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/arm64,linux/mips64le,linux/ppc64le,linux/riscv64,linux/s390x
       - run:
           name: Inspect & bootstrap docker-multiarch builder
@@ -162,7 +162,7 @@ jobs:
       - run:
           name: Create docker-multiarch builder
           command: >
-            docker buildx create --name docker-multiarch
+            docker buildx create --name docker-multiarch tls-environment
             --platform linux/386,linux/amd64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/arm64,linux/mips64le,linux/ppc64le,linux/riscv64,linux/s390x
       - run:
           name: Inspect & bootstrap docker-multiarch builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,8 +533,6 @@ workflows:
             - fetch-plugins
       - fetch-plugins:
           filters:
-            branches:
-              ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+.*/
       - wait-for-validation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
           paths:
             - "*"
   build-docker:
+    resource_class: large
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:
@@ -127,6 +128,7 @@ jobs:
             ghr -t ${GHI_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/
 
   publish-docker-release:
+    resource_class: large
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-artifacts/stanza_darwin_amd64
-artifacts/stanza_windows_amd64
+artifacts/
 .git/
 dev/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,31 @@
 FROM golang:1.16 as stage
 
+ARG plugins_url="https://github.com/observiq/stanza-plugins/releases/latest/download/stanza-plugins.zip"
+# arm cross builds do not have these symlinks in palce
+RUN \
+    ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split && \
+    ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb && \
+    ln -s /bin/tar /usr/sbin/tar && \
+    ln -s /bin/rm /usr/sbin/rm && \
+    echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections
+# unzip is required because tar does not work on arm
+RUN apt-get update && apt-get install unzip -y
+WORKDIR /stanza/artifacts
+RUN curl -fL "${plugins_url}" -o stanza-plugins.zip
+RUN unzip stanza-plugins.zip
 WORKDIR /stanza
 COPY . .
-RUN rm -rf artifacts/*
 RUN make build
-WORKDIR /stanza/artifacts
-# hack: "mv stanza_* stanza" gives an error because mv does not like '_*'
-RUN for f in stanza_*; do mv "$f" stanza; done
+RUN mv "artifacts/stanza_$(go env GOOS)_$(go env GOARCH)" artifacts/stanza
+
 
 FROM gcr.io/observiq-container-images/stanza-base:v1.1.0
 
 RUN mkdir -p /stanza_home
 ENV STANZA_HOME=/stanza_home
 RUN echo "pipeline:\n" >> /stanza_home/config.yaml
-
 COPY --from=stage /stanza/artifacts/stanza /stanza_home/stanza
-COPY ./artifacts/stanza-plugins.tar.gz /tmp/stanza-plugins.tar.gz
-RUN tar -zxvf /tmp/stanza-plugins.tar.gz -C /stanza_home/
+COPY --from=stage /stanza/artifacts/plugins /stanza_home/plugins
 ENTRYPOINT /stanza_home/stanza \
   --config /stanza_home/config.yaml \
   --database /stanza_home/stanza.db \


### PR DESCRIPTION
## Description of Changes

- re-worked `publish-docker-release` to actually work
  - configure docker context and buildx correctly
  - build with `plain` output, which is nicer to watch in circle ci
- added `build-docker`
  - identical to `publish-docker-release`, but does not push the built image
  - runs on every PR so we can be sure image builds are working, not just during release
- reworked dockerfile to use two stage build
  - build binary in golang container, which gives us auto detection of GOARCH
  - download and unzip plugins inside the stage container, and copy the plugins/ directory

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
