### PR TITLE
specify recent gcloud sdk version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,8 @@ jobs:
           command: GOPROXY=direct go get github.com/observiq/amazon-log-agent-benchmark-tool/cmd/logbench/ &&
             go build -o ./bin/logbench github.com/observiq/amazon-log-agent-benchmark-tool/cmd/logbench/
 
-      - gcp-cli/install
+      - gcp-cli/install:
+          version: "354.0.0"
       - gcp-cli/initialize:
           gcloud-service-key: SERVICE_ACCOUNT
           google-project-id: PROJECT


### PR DESCRIPTION
## Description of Changes

Benchmarks fail because the circle ci gcloud orb is installing an old version of the sdk.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
