### PR TITLE
Added the --all option to journald and cleaned up wait groups

### DIFF
--- a/operator/builtin/input/journald/journald.go
+++ b/operator/builtin/input/journald/journald.go
@@ -58,6 +58,9 @@ func (c JournaldInputConfig) Build(buildContext operator.BuildContext) ([]operat
 	// Export logs as JSON
 	args = append(args, "--output=json")
 
+	// Show all fields without encoding or truncation
+	args = append(args, "--all")
+
 	// Give raw json output and then exit the process
 	args = append(args, "--no-pager")
 
@@ -138,11 +141,12 @@ func (operator *JournaldInput) Start() error {
 // checking if there are new files or new logs in the watched files
 func (operator *JournaldInput) startPoller(ctx context.Context) {
 	operator.Debug("starting poller")
-	go func() {
-		globTicker := time.NewTicker(operator.pollInterval)
-		operator.wg.Add(1)
+	operator.wg.Add(1)
 
+	go func() {
 		defer operator.wg.Done()
+
+		globTicker := time.NewTicker(operator.pollInterval)
 		defer globTicker.Stop()
 
 		for {
@@ -163,9 +167,6 @@ func (operator *JournaldInput) startPoller(ctx context.Context) {
 
 // poll checks all the watched paths for new entries
 func (operator *JournaldInput) poll(ctx context.Context) error {
-	operator.wg.Add(1)
-
-	defer operator.wg.Done()
 	defer operator.syncOffsets()
 
 	// Start from a cursor if there is a saved offset


### PR DESCRIPTION
## Description of Changes
- Added the `--all` flag to the journald operator. This will prevent entries exceeding 4096 bytes from being encoded as null.
- Corrected the wait group to be incremented outside of the goroutine to avoid race conditions.
- Removed superfluous call to the wait group in the polling function.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
