### PR TITLE
File delete

### DIFF
--- a/docs/operators/file_input.md
+++ b/docs/operators/file_input.md
@@ -16,9 +16,10 @@ The `file_input` operator reads logs from files. It will place the lines read in
 | `encoding`             | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options               |
 | `include_file_name`    | `true`           | Whether to add the file name as the label `file_name`                                                              |
 | `include_file_path`    | `false`          | Whether to add the file path as the label `file_path`                                                              |
-| `include_file_name_resolved`    | `false`          | Whether to add the file name after symlinks resolution as the label `file_name_resolved`                       |
-| `include_file_path_resolved`    | `false`          | Whether to add the file path after symlinks resolution as the label `file_path_resolved`                       |
+| `include_file_name_resolved`    | `false`          | Whether to add the file name after symlinks resolution as the label `file_name_resolved`                  |
+| `include_file_path_resolved`    | `false`          | Whether to add the file path after symlinks resolution as the label `file_path_resolved`                  |
 | `start_at`             | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
+| `delete_after_read`    | `false`          | After reading a to the end of a file, delete it. Cannot be `true` when `start_at` is `end`.                        |
 | `fingerprint_size`     | `1kb`            | The number of bytes with which to identify a file. The first bytes in the file are used as the fingerprint. Decreasing this value at any point will cause existing fingerprints to forgotten, meaning that all files will be read from the beginning (one time). |
 | `max_log_size`         | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |
 | `max_concurrent_files` | 1024             | The maximum number of log files from which logs will be read concurrently (minimum = 2). If the number of files matched in the `include` pattern exceeds half of this number, then files will be processed in batches. One batch will be processed per `poll_interval`. |

--- a/operator/builtin/input/file/config.go
+++ b/operator/builtin/input/file/config.go
@@ -54,6 +54,7 @@ type InputConfig struct {
 	FingerprintSize         helper.ByteSize        `json:"fingerprint_size,omitempty"            yaml:"fingerprint_size,omitempty"`
 	MaxLogSize              helper.ByteSize        `json:"max_log_size,omitempty"                yaml:"max_log_size,omitempty"`
 	MaxConcurrentFiles      int                    `json:"max_concurrent_files,omitempty"        yaml:"max_concurrent_files,omitempty"`
+	DeleteAfterRead         bool                   `json:"delete_after_read,omitempty"           yaml:"delete_after_read,omitempty"`
 	LabelRegex              string                 `json:"label_regex,omitempty"                 yaml:"label_regex,omitempty"`
 	Encoding                helper.EncodingConfig  `json:",inline,omitempty"                     yaml:",inline,omitempty"`
 }
@@ -114,6 +115,9 @@ func (c InputConfig) Build(context operator.BuildContext) ([]operator.Operator, 
 	case "beginning":
 		startAtBeginning = true
 	case "end":
+		if c.DeleteAfterRead {
+			return nil, fmt.Errorf("delete_after_read cannot be used with start_at 'end'")
+		}
 		startAtBeginning = false
 	default:
 		return nil, fmt.Errorf("invalid start_at location '%s'", c.StartAt)
@@ -173,6 +177,7 @@ func (c InputConfig) Build(context operator.BuildContext) ([]operator.Operator, 
 		FilePathResolvedField: filePathResolvedField,
 		FileNameResolvedField: fileNameResolvedField,
 		startAtBeginning:      startAtBeginning,
+		deleteAfterRead:       c.DeleteAfterRead,
 		queuedMatches:         make([]string, 0),
 		labelRegex:            labelRegex,
 		encoding:              encoding,

--- a/operator/builtin/input/file/config_test.go
+++ b/operator/builtin/input/file/config_test.go
@@ -678,6 +678,15 @@ func TestBuild(t *testing.T) {
 			require.Error,
 			nil,
 		},
+		{
+			"InvalidStartAtDelete",
+			func(f *InputConfig) {
+				f.StartAt = "end"
+				f.DeleteAfterRead = true
+			},
+			require.Error,
+			nil,
+		},
 	}
 
 	for _, tc := range cases {

--- a/operator/builtin/input/file/file.go
+++ b/operator/builtin/input/file/file.go
@@ -174,14 +174,16 @@ OUTER:
 	// Wait until all the reader goroutines are finished
 	wg.Wait()
 
-	// Rotate files for next poll
-	if !f.deleteAfterRead {
-		for _, reader := range f.lastPollReaders {
-			reader.Close()
-		}
-
-		f.lastPollReaders = readers
+	if f.deleteAfterRead {
+		// No need to track files, since we only consume them once
+		return
 	}
+
+	for _, reader := range f.lastPollReaders {
+		reader.Close()
+	}
+
+	f.lastPollReaders = readers
 
 	f.saveCurrent(readers)
 	f.syncLastPollFiles()

--- a/operator/builtin/input/file/file_test.go
+++ b/operator/builtin/input/file/file_test.go
@@ -624,6 +624,7 @@ func TestDeleteAfterRead(t *testing.T) {
 			temp.WriteString(message + "\n")
 			expectedMessages = append(expectedMessages, message)
 		}
+		require.NoError(t, temp.Close())
 	}
 
 	operator.poll(context.Background())


### PR DESCRIPTION
## Description of Changes
Adds an option to `file_input` called `delete_after_read`. When set to `true`, files will be deleted immediately after the operator finds the EOF.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
