### PR TITLE
support hidden and advanced_config plugin params

### DIFF
--- a/plugin/parameter.go
+++ b/plugin/parameter.go
@@ -28,8 +28,10 @@ type Parameter struct {
 	ValidValues []string `json:"validValues" yaml:"valid_values"`
 
 	// Must be valid according to Type & ValidValues
-	Default    interface{}                       `json:"default" yaml:"default"`
-	RelevantIf map[string]map[string]interface{} `json:"relevantIf" yaml:"relevant_if"`
+	Default        interface{}                       `json:"default" yaml:"default"`
+	RelevantIf     map[string]map[string]interface{} `json:"relevantIf" yaml:"relevant_if"`
+	Hidden         bool                              `json:"hidden" yaml:"hidden"`
+	AdvancedConfig bool                              `json:"advanced_config" yaml:"advanced_config"`
 }
 
 func (p Parameter) validateValue(value interface{}) error {

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -578,6 +578,46 @@ parameters:
 pipeline:
 `,
 		},
+		{
+			name:      "hidden",
+			expectErr: true,
+			template: `version: 0.0.0
+title: Test Plugin
+description: This is a test plugin
+parameters:
+  - name: path
+    label: Parameter
+    description: The thing of the thing
+    type: int
+    valid_values: [1, 2, 3]
+  - name: listen_address
+    label: network socket
+	description: Network socket to listen on
+	type: string
+	hidden: true
+pipeline:
+`,
+		},
+		{
+			name:      "advanced-config",
+			expectErr: true,
+			template: `version: 0.0.0
+title: Test Plugin
+description: This is a test plugin
+parameters:
+  - name: path
+    label: Parameter
+    description: The thing of the thing
+    type: int
+    valid_values: [1, 2, 3]
+  - name: listen_address
+    label: network socket
+	description: Network socket to listen on
+	type: string
+	advanced_config: true
+pipeline:
+`,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Description of Changes

Some plugins have `hidden` and `advanced_config` to allow platforms to determine if the parameter should be hidden from the user or tucked into an "advanced" configuration section.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
