### PR TITLE
file_input uses a reasonable default for max_concurrent_files

### DIFF
--- a/operator/builtin/input/file/config.go
+++ b/operator/builtin/input/file/config.go
@@ -90,7 +90,9 @@ func (c InputConfig) Build(context operator.BuildContext) ([]operator.Operator, 
 		return nil, fmt.Errorf("`max_log_size` must be positive")
 	}
 
-	if c.MaxConcurrentFiles <= 1 {
+	if c.MaxConcurrentFiles == 0 {
+		c.MaxConcurrentFiles = defaultMaxConcurrentFiles
+	} else if c.MaxConcurrentFiles <= 1 {
 		return nil, fmt.Errorf("`max_concurrent_files` must be greater than 1")
 	}
 

--- a/operator/builtin/input/file/config_test.go
+++ b/operator/builtin/input/file/config_test.go
@@ -550,7 +550,32 @@ func TestBuild(t *testing.T) {
 				require.Equal(t, f.FilePathField, entry.NewNilField())
 				require.Equal(t, f.FileNameField, entry.NewLabelField("file_name"))
 				require.Equal(t, f.PollInterval, 10*time.Millisecond)
+				require.Equal(t, f.MaxConcurrentFiles, defaultMaxConcurrentFiles)
 			},
+		},
+		{
+			"MaxConcurrentFilesCustom",
+			func(f *InputConfig) {
+				f.MaxConcurrentFiles = 100
+				return
+			},
+			require.NoError,
+			func(t *testing.T, f *InputOperator) {
+				require.Equal(t, f.OutputOperators[0], fakeOutput)
+				require.Equal(t, f.Include, []string{"/var/log/testpath.*"})
+				require.Equal(t, f.FilePathField, entry.NewNilField())
+				require.Equal(t, f.FileNameField, entry.NewLabelField("file_name"))
+				require.Equal(t, f.PollInterval, 10*time.Millisecond)
+				require.Equal(t, f.MaxConcurrentFiles, 100)
+			},
+		},
+		{
+			"MaxConcurrentFilesInvalid",
+			func(f *InputConfig) {
+				f.MaxConcurrentFiles = 1 // must be at least 2
+			},
+			require.Error,
+			nil,
 		},
 		{
 			"BadIncludeGlob",


### PR DESCRIPTION
## Description of Changes

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
