### PR TITLE
Google output resource to labels

### DIFF
--- a/operator/builtin/output/googlecloud/google_cloud.go
+++ b/operator/builtin/output/googlecloud/google_cloud.go
@@ -369,5 +369,18 @@ func (g *GoogleCloudOutput) createProtobufEntry(e *entry.Entry) (newEntry *logpb
 
 	newEntry.Resource = getResource(e)
 
+	// Google monitored resources wipe out Stanza's entry.Resources with
+	// a static set of resources, therefore we need to move the entry's resources
+	// to entry.Labels
+	for k, v := range e.Resource {
+		if val, ok := newEntry.Labels[k]; ok {
+			if val != v {
+				g.Warnf("resource to labels merge failed, entry has label %s=%s, tried to add %s=%s", k, val, k, v)
+			}
+			continue
+		}
+		newEntry.Labels[k] = v
+	}
+
 	return newEntry, nil
 }

--- a/operator/builtin/output/googlecloud/resource.go
+++ b/operator/builtin/output/googlecloud/resource.go
@@ -9,12 +9,7 @@ import (
 // https://cloud.google.com/logging/docs/api/v2/resource-list#resource-types
 
 func getResource(e *entry.Entry) *mrpb.MonitoredResource {
-	rt := detectResourceType(e)
-	if rt == "" {
-		return nil
-	}
-
-	switch rt {
+	switch detectResourceType(e) {
 	case "k8s_pod":
 		return k8sPodResource(e)
 	case "k8s_container":
@@ -23,11 +18,9 @@ func getResource(e *entry.Entry) *mrpb.MonitoredResource {
 		return k8sNodeResource(e)
 	case "k8s_cluster":
 		return k8sClusterResource(e)
-	case "generic_node":
+	default:
 		return genericNodeResource(e)
 	}
-
-	return nil
 }
 
 func detectResourceType(e *entry.Entry) string {

--- a/operator/builtin/output/googlecloud/resource.go
+++ b/operator/builtin/output/googlecloud/resource.go
@@ -9,7 +9,12 @@ import (
 // https://cloud.google.com/logging/docs/api/v2/resource-list#resource-types
 
 func getResource(e *entry.Entry) *mrpb.MonitoredResource {
-	switch detectResourceType(e) {
+	rt := detectResourceType(e)
+	if rt == "" {
+		return nil
+	}
+
+	switch rt {
 	case "k8s_pod":
 		return k8sPodResource(e)
 	case "k8s_container":
@@ -18,9 +23,11 @@ func getResource(e *entry.Entry) *mrpb.MonitoredResource {
 		return k8sNodeResource(e)
 	case "k8s_cluster":
 		return k8sClusterResource(e)
-	default:
+	case "generic_node":
 		return genericNodeResource(e)
 	}
+
+	return nil
 }
 
 func detectResourceType(e *entry.Entry) string {


### PR DESCRIPTION
## Description of Changes

Google Output operator relies on [managed resources](https://cloud.google.com/logging/docs/api/v2/resource-list#resource-types), which have a static set of resources and resources.labels. This causes any Stanza entry.Resources to be wiped out.

I have not found a way to use managed resources and preserve stanza's resources, so my solution involves moving stanza's resources to the cloud logging labels. 

This works by checking to see if the label already exists, adding it if not. A warning is logged if a label already exists with a different value, to protect against data loss. I think this would be a rare situation.

Before
<img width="1491" alt="Screen Shot 2021-09-15 at 2 49 33 PM" src="https://user-images.githubusercontent.com/23043836/133491973-f7b525dd-259d-4748-96df-3880be683a29.png">

After
<img width="1483" alt="Screen Shot 2021-09-15 at 2 57 36 PM" src="https://user-images.githubusercontent.com/23043836/133493092-c28c1a24-6572-4927-a919-317af814d561.png">


## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
