### PR TITLE
Improvements to the way delete_after_read works

### DIFF
--- a/operator/builtin/input/file/reader.go
+++ b/operator/builtin/input/file/reader.go
@@ -174,7 +174,7 @@ func (f *Reader) readHeaders(ctx context.Context, msgBuf []byte) error {
 func (f *Reader) Close() {
 	if f.file != nil {
 		if err := f.file.Close(); err != nil {
-			f.Debugf("Problem closing reader", "Error", err.Error())
+			f.Warnf("Problem closing reader", "Error", err.Error())
 		}
 	}
 }


### PR DESCRIPTION
- Wait until end of poll cycle and then delete files from the primary
  goroutine
- Update checkpoints, even though in thoery files are consumed fully
- If file.Close fails, log at Warn level instead of Debug

## Description of Changes

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
