### PR TITLE
check for nil connection before closing, resolves panic

### DIFF
--- a/operator/builtin/input/tcp/tcp.go
+++ b/operator/builtin/input/tcp/tcp.go
@@ -290,8 +290,10 @@ func (t *TCPInput) goHandleMessages(ctx context.Context, conn net.Conn, cancel c
 func (t *TCPInput) Stop() error {
 	t.cancel()
 
-	if err := t.listener.Close(); err != nil {
-		return err
+	if t.listener != nil {
+		if err := t.listener.Close(); err != nil {
+			return err
+		}
 	}
 
 	t.wg.Wait()

--- a/operator/builtin/input/udp/udp.go
+++ b/operator/builtin/input/udp/udp.go
@@ -143,8 +143,10 @@ func (u *UDPInput) readMessage() (string, net.Addr, error) {
 // Stop will stop listening for udp messages.
 func (u *UDPInput) Stop() error {
 	u.cancel()
-	if err := u.connection.Close(); err != nil {
-		u.Errorf("failed to close connection, got error: %s", err)
+	if u.connection != nil {
+		if err := u.connection.Close(); err != nil {
+			u.Errorf("failed to close connection, got error: %s", err)
+		}
 	}
 	u.wg.Wait()
 	return nil


### PR DESCRIPTION
## Description of Changes

If a port is already bound, Stanza fails (correctly) but panics during Stop() because the connection is nil and therefor cannot have Close() called.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
