### PR TITLE
build docker only on commit to master or tag. it takes too long with …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,6 +535,8 @@ workflows:
               only: /^v\d+\.\d+\.\d+.*/
       - build-docker:
           filters:
+            branches:
+              only: master
             tags:
               only: /^v\d+\.\d+\.\d+.*/
           requires:
@@ -569,6 +571,7 @@ workflows:
       - publish-docker-release:
           requires:
             - wait-for-validation
+            - build-docker
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
PR builds take a long time due to building docker with dockerx (emulating arm environments for the arm64 image). I think we should only perform the build on commit to master.