### PR TITLE
Cloudwatch input should not store pointers on entry

### DIFF
--- a/operator/builtin/input/aws/cloudwatch/cloudwatch.go
+++ b/operator/builtin/input/aws/cloudwatch/cloudwatch.go
@@ -15,7 +15,7 @@ import (
 )
 
 const operatorName = "aws_cloudwatch_input"
-const eventLimit = 10_000 //The maximum number of events to return. The default is up to 10,000 events or max of 1mb.
+const eventLimit = 10_000 // The maximum number of events to return. The default is up to 10,000 events or max of 1mb.
 
 func init() {
 	operator.Register(operatorName, func() operator.Builder { return NewCloudwatchConfig("") })

--- a/operator/builtin/input/aws/cloudwatch/cloudwatch_test.go
+++ b/operator/builtin/input/aws/cloudwatch/cloudwatch_test.go
@@ -1,11 +1,17 @@
 package cloudwatch
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	cwLogs "github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+
+	"github.com/observiq/stanza/entry"
+	"github.com/observiq/stanza/operator"
 	"github.com/observiq/stanza/operator/helper"
 	"github.com/observiq/stanza/testutil"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -406,6 +412,103 @@ func TestTimeLayoutParser(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.expected, timeLayoutParser(tc.input, time.Unix(tc.timeToUse, 0)))
+		})
+	}
+}
+
+func TestHandleEvent(t *testing.T) {
+	cfg := NewCloudwatchConfig("")
+	cfg.LogGroupName = "logGroupName"
+	cfg.LogGroups = []string{}
+	cfg.Region = "us-west-2"
+	ops, err := cfg.Build(testutil.NewBuildContext(t))
+	require.NoError(t, err)
+
+	op := ops[0]
+
+	cwOperator, ok := op.(*CloudwatchInput)
+	require.True(t, ok)
+	logStreamName, eventID, ingestionTime := "logStream", "eventID", int64(10000)
+	ts := int64(1632240412056)
+	msg := "test-message"
+	logGroupName := "logGroupName"
+
+	cases := []struct {
+		name         string
+		event        *cwLogs.FilteredLogEvent
+		logGroupName string
+		expected     *entry.Entry
+	}{
+		{
+			name:         "no nil",
+			logGroupName: logGroupName,
+			event: &cwLogs.FilteredLogEvent{
+				EventId:       &eventID,
+				IngestionTime: &ingestionTime,
+				LogStreamName: &logStreamName,
+				Message:       &msg,
+				Timestamp:     &ts,
+			},
+			expected: &entry.Entry{
+				Timestamp: fromUnixMilli(ts),
+				Record: map[string]interface{}{
+					"ingestion_time": ingestionTime,
+					"message":        msg,
+				},
+				Resource: map[string]string{
+					"event_id":   eventID,
+					"log_group":  logGroupName,
+					"log_stream": logStreamName,
+					"region":     cwOperator.region,
+				},
+			},
+		},
+		{
+			name:         "no message",
+			logGroupName: logGroupName,
+			event: &cwLogs.FilteredLogEvent{
+				EventId:       &eventID,
+				IngestionTime: &ingestionTime,
+				LogStreamName: &logStreamName,
+				Timestamp:     &ts,
+			},
+			expected: &entry.Entry{
+				Timestamp: fromUnixMilli(ts),
+				Record: map[string]interface{}{
+					"ingestion_time": ingestionTime,
+				},
+				Resource: map[string]string{
+					"event_id":   eventID,
+					"log_group":  logGroupName,
+					"log_stream": logStreamName,
+					"region":     cwOperator.region,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
+			var outputEntry *entry.Entry
+			if tc.expected != nil {
+				mockOut := testutil.NewMockOperator("output")
+				cwOperator.OutputOperators = []operator.Operator{mockOut}
+				defer func() {
+					cwOperator.OutputOperators = []operator.Operator{}
+				}()
+
+				mockOut.On("Process", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+					e := args[1]
+					outputEntry, ok = e.(*entry.Entry)
+					require.True(t, ok)
+				})
+				require.NoError(t, err)
+			}
+			cwOperator.handleEvent(ctx, tc.event, tc.logGroupName)
+			if outputEntry != nil {
+				require.Equal(t, tc.expected, outputEntry)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description of Changes

Entries should not be storing fields with pointers. This causes complications further when we try to refer to these fields using other operators that cannot reflect the type because it is a generic pointer `interface{}`. For example cloudwatch entries going into the filter operator will get this error: 
```yaml
- type: filter
  expr: '$record.message != nil and $record.message matches ".*warm[\\d\\D]*"'
```

yields:

```JSON
{"level":"error","ts":"2021-09-21T02:06:26.026Z","msg":"Running expressing returned an error%!(EXTRA zapcore.Field={error 26 0  interface conversion: interface {} is *string, not string (1:44)\n | $record.message != nil and $record.message matches \".*warm[\\\\d\\\\D]*\"\n | 
```

And this is because $record.message was being stored as a `*string` rather than a raw `string`

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
