### PR TITLE
Google output location

### DIFF
--- a/docs/operators/google_cloud_output.md
+++ b/docs/operators/google_cloud_output.md
@@ -11,7 +11,7 @@ The `google_cloud_output` operator will send entries to Google Cloud Logging.
 | `credentials_file` |                       | A path to a file containing the JSON-formatted credentials                                                 |
 | `project_id`       |                       | The Google Cloud project ID the logs should be sent to. Defaults to project_id found in credentials        |
 | `log_name_field`   |                       | A [field](/docs/types/field.md) for the log name on the entry. Log name defaults to `default` if unset     |
-| `location`         |                       | A [field](/docs/types/field.md) for the log location resource when an entry [fulfills a monitored resource type's requirements](https://cloud.google.com/logging/docs/api/v2/resource-list#resource-types) |
+| `location_field`   |                       | A [field](/docs/types/field.md) for the log location resource when an entry [fulfills a monitored resource type's requirements](https://cloud.google.com/logging/docs/api/v2/resource-list#resource-types) |
 | `severity_field`   |                       | A [field](/docs/types/field.md) for the severity on the log entry                                          |
 | `trace_field`      |                       | A [field](/docs/types/field.md) for the trace on the log entry                                             |
 | `span_id_field`    |                       | A [field](/docs/types/field.md) for the span_id on the log entry                                           |

--- a/docs/operators/google_cloud_output.md
+++ b/docs/operators/google_cloud_output.md
@@ -11,7 +11,7 @@ The `google_cloud_output` operator will send entries to Google Cloud Logging.
 | `credentials_file` |                       | A path to a file containing the JSON-formatted credentials                                                 |
 | `project_id`       |                       | The Google Cloud project ID the logs should be sent to. Defaults to project_id found in credentials        |
 | `log_name_field`   |                       | A [field](/docs/types/field.md) for the log name on the entry. Log name defaults to `default` if unset     |
-| `location`         |                       | A [field](/docs/types/field.md) for the log location resource on the entry                                 |
+| `location`         |                       | A [field](/docs/types/field.md) for the log location resource when an entry [fulfills a monitored resource type's requirements](https://cloud.google.com/logging/docs/api/v2/resource-list#resource-types) |
 | `severity_field`   |                       | A [field](/docs/types/field.md) for the severity on the log entry                                          |
 | `trace_field`      |                       | A [field](/docs/types/field.md) for the trace on the log entry                                             |
 | `span_id_field`    |                       | A [field](/docs/types/field.md) for the span_id on the log entry                                           |

--- a/docs/operators/google_cloud_output.md
+++ b/docs/operators/google_cloud_output.md
@@ -11,6 +11,7 @@ The `google_cloud_output` operator will send entries to Google Cloud Logging.
 | `credentials_file` |                       | A path to a file containing the JSON-formatted credentials                                                 |
 | `project_id`       |                       | The Google Cloud project ID the logs should be sent to. Defaults to project_id found in credentials        |
 | `log_name_field`   |                       | A [field](/docs/types/field.md) for the log name on the entry. Log name defaults to `default` if unset     |
+| `location`         |                       | A [field](/docs/types/field.md) for the log location resource on the entry                                 |
 | `severity_field`   |                       | A [field](/docs/types/field.md) for the severity on the log entry                                          |
 | `trace_field`      |                       | A [field](/docs/types/field.md) for the trace on the log entry                                             |
 | `span_id_field`    |                       | A [field](/docs/types/field.md) for the span_id on the log entry                                           |

--- a/operator/builtin/output/googlecloud/google_cloud.go
+++ b/operator/builtin/output/googlecloud/google_cloud.go
@@ -52,7 +52,7 @@ type GoogleCloudOutputConfig struct {
 	CredentialsFile     string          `json:"credentials_file,omitempty" yaml:"credentials_file,omitempty"`
 	ProjectID           string          `json:"project_id"                 yaml:"project_id"`
 	LogNameField        *entry.Field    `json:"log_name_field,omitempty"   yaml:"log_name_field,omitempty"`
-	Location            *entry.Field    `json:"location,omitempty"   yaml:"location,omitempty"`
+	LocationField       *entry.Field    `json:"location_field,omitempty"   yaml:"location_field,omitempty"`
 	TraceField          *entry.Field    `json:"trace_field,omitempty"      yaml:"trace_field,omitempty"`
 	SpanIDField         *entry.Field    `json:"span_id_field,omitempty"    yaml:"span_id_field,omitempty"`
 	Timeout             helper.Duration `json:"timeout,omitempty"          yaml:"timeout,omitempty"`
@@ -82,7 +82,7 @@ func (c GoogleCloudOutputConfig) Build(bc operator.BuildContext) ([]operator.Ope
 		buffer:          newBuffer,
 		flusher:         newFlusher,
 		logNameField:    c.LogNameField,
-		location:        c.Location,
+		locationField:   c.LocationField,
 		traceField:      c.TraceField,
 		spanIDField:     c.SpanIDField,
 		timeout:         c.Timeout.Raw(),
@@ -105,7 +105,7 @@ type GoogleCloudOutput struct {
 	projectID       string
 
 	logNameField   *entry.Field
-	location       *entry.Field
+	locationField  *entry.Field
 	traceField     *entry.Field
 	spanIDField    *entry.Field
 	useCompression bool
@@ -372,14 +372,14 @@ func (g *GoogleCloudOutput) createProtobufEntry(e *entry.Entry) (newEntry *logpb
 
 	newEntry.Resource = getResource(e)
 
-	if g.location != nil && newEntry.Resource != nil {
+	if g.locationField != nil && newEntry.Resource != nil {
 		var rawLocation string
-		err := e.Read(*g.location, &rawLocation)
+		err := e.Read(*g.locationField, &rawLocation)
 		if err != nil {
 			g.Warnw("Failed to set location", zap.Error(err), "entry", e)
 		} else {
 			newEntry.Resource.Labels["location"] = rawLocation
-			e.Delete(*g.location)
+			e.Delete(*g.locationField)
 		}
 	}
 

--- a/operator/builtin/output/googlecloud/google_cloud_test.go
+++ b/operator/builtin/output/googlecloud/google_cloud_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/option"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
+	mrpb "google.golang.org/genproto/googleapis/api/monitoredres"
 	sev "google.golang.org/genproto/googleapis/logging/type"
 	logpb "google.golang.org/genproto/googleapis/logging/v2"
 	"google.golang.org/grpc"
@@ -110,6 +111,305 @@ func TestGoogleCloudOutput(t *testing.T) {
 						Payload: &logpb.LogEntry_JsonPayload{JsonPayload: jsonMapToProtoStruct(map[string]interface{}{
 							"message": "test message",
 						})},
+					},
+				}
+				return req
+			}(),
+		},
+		{
+			"k8s_pod",
+			func() *GoogleCloudOutputConfig {
+				c := googleCloudBasicConfig()
+				f := entry.NewRecordField("log_name")
+				locationField := entry.NewLabelField("region")
+				c.LogNameField = &f
+				c.Location = &locationField
+				return c
+			}(),
+			&entry.Entry{
+				Timestamp: now,
+				Record: map[string]interface{}{
+					"message":  "test message",
+					"log_name": "app-pod",
+				},
+				Resource: map[string]string{
+					"k8s.pod.name":       "test-pod",
+					"k8s.cluster.name":   "test-cluster",
+					"k8s.namespace.name": "test-namespace",
+				},
+				Labels: map[string]string{
+					"region": "us-east1",
+				},
+			},
+			func() *logpb.WriteLogEntriesRequest {
+				req := googleCloudBasicWriteEntriesRequest()
+				req.Entries = []*logpb.LogEntry{
+					{
+						LogName:   "projects/test_project_id/logs/app-pod",
+						Timestamp: protoTs,
+						Payload: &logpb.LogEntry_JsonPayload{JsonPayload: jsonMapToProtoStruct(map[string]interface{}{
+							"message": "test message",
+						})},
+						Resource: &mrpb.MonitoredResource{
+							Type: "k8s_pod",
+							Labels: map[string]string{
+								"pod_name":       "test-pod",
+								"cluster_name":   "test-cluster",
+								"namespace_name": "test-namespace",
+								"location":       "us-east1",
+							},
+						},
+					},
+				}
+				return req
+			}(),
+		},
+		{
+			"k8s_container",
+			func() *GoogleCloudOutputConfig {
+				c := googleCloudBasicConfig()
+				f := entry.NewRecordField("log_name")
+				locationField := entry.NewRecordField("region")
+				c.LogNameField = &f
+				c.Location = &locationField
+				return c
+			}(),
+			&entry.Entry{
+				Timestamp: now,
+				Record: map[string]interface{}{
+					"message":  "test message",
+					"log_name": "app-pod",
+					"region":   "us-west1",
+				},
+				Resource: map[string]string{
+					"container.name":     "test-container",
+					"k8s.pod.name":       "test-pod",
+					"k8s.cluster.name":   "test-cluster",
+					"k8s.namespace.name": "test-namespace",
+				},
+			},
+			func() *logpb.WriteLogEntriesRequest {
+				req := googleCloudBasicWriteEntriesRequest()
+				req.Entries = []*logpb.LogEntry{
+					{
+						LogName:   "projects/test_project_id/logs/app-pod",
+						Timestamp: protoTs,
+						Payload: &logpb.LogEntry_JsonPayload{JsonPayload: jsonMapToProtoStruct(map[string]interface{}{
+							"message": "test message",
+							"region":  "us-west1",
+						})},
+						Resource: &mrpb.MonitoredResource{
+							Type: "k8s_container",
+							Labels: map[string]string{
+								"container_name": "test-container",
+								"pod_name":       "test-pod",
+								"cluster_name":   "test-cluster",
+								"namespace_name": "test-namespace",
+								"location":       "us-west1",
+							},
+						},
+					},
+				}
+				return req
+			}(),
+		},
+		{
+			"k8s_container_alt",
+			func() *GoogleCloudOutputConfig {
+				c := googleCloudBasicConfig()
+				f := entry.NewRecordField("log_name")
+				locationField := entry.NewRecordField("region")
+				c.LogNameField = &f
+				c.Location = &locationField
+				return c
+			}(),
+			&entry.Entry{
+				Timestamp: now,
+				Record: map[string]interface{}{
+					"message":  "test message",
+					"log_name": "app-pod",
+					"region":   "us-central1",
+				},
+				Resource: map[string]string{
+					// "k8s.container.name" instead of container.name
+					"k8s.container.name": "test-container",
+					"k8s.pod.name":       "test-pod",
+					"k8s.cluster.name":   "test-cluster",
+					"k8s.namespace.name": "test-namespace",
+				},
+			},
+			func() *logpb.WriteLogEntriesRequest {
+				req := googleCloudBasicWriteEntriesRequest()
+				req.Entries = []*logpb.LogEntry{
+					{
+						LogName:   "projects/test_project_id/logs/app-pod",
+						Timestamp: protoTs,
+						Payload: &logpb.LogEntry_JsonPayload{JsonPayload: jsonMapToProtoStruct(map[string]interface{}{
+							"message": "test message",
+							"region":  "us-central1",
+						})},
+						Resource: &mrpb.MonitoredResource{
+							Type: "k8s_container",
+							Labels: map[string]string{
+								"container_name": "test-container",
+								"pod_name":       "test-pod",
+								"cluster_name":   "test-cluster",
+								"namespace_name": "test-namespace",
+								"location":       "us-central1",
+							},
+						},
+					},
+				}
+				return req
+			}(),
+		},
+		{
+			"k8s_node",
+			func() *GoogleCloudOutputConfig {
+				c := googleCloudBasicConfig()
+				f := entry.NewRecordField("log_name")
+				locationField := entry.NewResourceField("region")
+				c.LogNameField = &f
+				c.Location = &locationField
+				return c
+			}(),
+			&entry.Entry{
+				Timestamp: now,
+				Record: map[string]interface{}{
+					"message":  "test message",
+					"log_name": "app-pod",
+				},
+				Resource: map[string]string{
+					"k8s.cluster.name": "test-cluster",
+					"host.name":        "test-node",
+					"region":           "us-west1",
+				},
+			},
+			func() *logpb.WriteLogEntriesRequest {
+				req := googleCloudBasicWriteEntriesRequest()
+				req.Entries = []*logpb.LogEntry{
+					{
+						LogName:   "projects/test_project_id/logs/app-pod",
+						Timestamp: protoTs,
+						Payload: &logpb.LogEntry_JsonPayload{JsonPayload: jsonMapToProtoStruct(map[string]interface{}{
+							"message": "test message",
+						})},
+						Resource: &mrpb.MonitoredResource{
+							Type: "k8s_node",
+							Labels: map[string]string{
+								"node_name":    "test-node",
+								"cluster_name": "test-cluster",
+								"location":     "us-west1",
+							},
+						},
+					},
+				}
+				return req
+			}(),
+		},
+		{
+			"k8s_cluster",
+			func() *GoogleCloudOutputConfig {
+				c := googleCloudBasicConfig()
+				f := entry.NewRecordField("log_name")
+				c.LogNameField = &f
+				return c
+			}(),
+			&entry.Entry{
+				Timestamp: now,
+				Record: map[string]interface{}{
+					"message":  "test message",
+					"log_name": "app-pod",
+				},
+				Resource: map[string]string{
+					"k8s.cluster.name": "test-cluster",
+					"region":           "us-west1",
+				},
+			},
+			func() *logpb.WriteLogEntriesRequest {
+				req := googleCloudBasicWriteEntriesRequest()
+				req.Entries = []*logpb.LogEntry{
+					{
+						LogName:   "projects/test_project_id/logs/app-pod",
+						Timestamp: protoTs,
+						Payload: &logpb.LogEntry_JsonPayload{JsonPayload: jsonMapToProtoStruct(map[string]interface{}{
+							"message": "test message",
+						})},
+						Resource: &mrpb.MonitoredResource{
+							Type: "k8s_cluster",
+							Labels: map[string]string{
+								"cluster_name": "test-cluster",
+							},
+						},
+						// Region label is preserved because Location field parameter is not set
+						Labels: map[string]string{
+							"region": "us-west1",
+						},
+					},
+				}
+				return req
+			}(),
+		},
+		{
+			"generic_node",
+			func() *GoogleCloudOutputConfig {
+				c := googleCloudBasicConfig()
+				return c
+			}(),
+			&entry.Entry{
+				Timestamp: now,
+				Record: map[string]interface{}{
+					"message": "test message",
+				},
+				Resource: map[string]string{
+					"host.name": "test-host",
+				},
+			},
+			func() *logpb.WriteLogEntriesRequest {
+				req := googleCloudBasicWriteEntriesRequest()
+				req.Entries = []*logpb.LogEntry{
+					{
+						Timestamp: protoTs,
+						Payload: &logpb.LogEntry_JsonPayload{JsonPayload: jsonMapToProtoStruct(map[string]interface{}{
+							"message": "test message",
+						})},
+						Resource: &mrpb.MonitoredResource{
+							Type: "generic_node",
+							Labels: map[string]string{
+								"node_id": "test-host",
+							},
+						},
+					},
+				}
+				return req
+			}(),
+		},
+		{
+			"unknown_resource_type",
+			func() *GoogleCloudOutputConfig {
+				c := googleCloudBasicConfig()
+				return c
+			}(),
+			&entry.Entry{
+				Timestamp: now,
+				Record: map[string]interface{}{
+					"message": "test message",
+				},
+				Resource: map[string]string{
+					"datacenter": "test-dc",
+				},
+			},
+			func() *logpb.WriteLogEntriesRequest {
+				req := googleCloudBasicWriteEntriesRequest()
+				req.Entries = []*logpb.LogEntry{
+					{
+						Timestamp: protoTs,
+						Payload: &logpb.LogEntry_JsonPayload{JsonPayload: jsonMapToProtoStruct(map[string]interface{}{
+							"message": "test message",
+						})},
+						Labels: map[string]string{
+							"datacenter": "test-dc",
+						},
 					},
 				}
 				return req

--- a/operator/builtin/output/googlecloud/google_cloud_test.go
+++ b/operator/builtin/output/googlecloud/google_cloud_test.go
@@ -123,7 +123,7 @@ func TestGoogleCloudOutput(t *testing.T) {
 				f := entry.NewRecordField("log_name")
 				locationField := entry.NewLabelField("region")
 				c.LogNameField = &f
-				c.Location = &locationField
+				c.LocationField = &locationField
 				return c
 			}(),
 			&entry.Entry{
@@ -171,7 +171,7 @@ func TestGoogleCloudOutput(t *testing.T) {
 				f := entry.NewRecordField("log_name")
 				locationField := entry.NewRecordField("region")
 				c.LogNameField = &f
-				c.Location = &locationField
+				c.LocationField = &locationField
 				return c
 			}(),
 			&entry.Entry{
@@ -220,7 +220,7 @@ func TestGoogleCloudOutput(t *testing.T) {
 				f := entry.NewRecordField("log_name")
 				locationField := entry.NewRecordField("region")
 				c.LogNameField = &f
-				c.Location = &locationField
+				c.LocationField = &locationField
 				return c
 			}(),
 			&entry.Entry{
@@ -270,7 +270,7 @@ func TestGoogleCloudOutput(t *testing.T) {
 				f := entry.NewRecordField("log_name")
 				locationField := entry.NewResourceField("region")
 				c.LogNameField = &f
-				c.Location = &locationField
+				c.LocationField = &locationField
 				return c
 			}(),
 			&entry.Entry{

--- a/operator/builtin/output/googlecloud/resource.go
+++ b/operator/builtin/output/googlecloud/resource.go
@@ -63,7 +63,7 @@ func hasResource(key string, e *entry.Entry) bool {
 }
 
 func k8sPodResource(e *entry.Entry) *mrpb.MonitoredResource {
-	return &mrpb.MonitoredResource{
+	m := &mrpb.MonitoredResource{
 		Type: "k8s_pod",
 		Labels: map[string]string{
 			"pod_name":       e.Resource["k8s.pod.name"],
@@ -72,10 +72,16 @@ func k8sPodResource(e *entry.Entry) *mrpb.MonitoredResource {
 			// TODO project id
 		},
 	}
+
+	delete(e.Resource, "k8s.pod.name")
+	delete(e.Resource, "k8s.namespace.name")
+	delete(e.Resource, "k8s.cluster.name")
+
+	return m
 }
 
 func k8sContainerResource(e *entry.Entry) *mrpb.MonitoredResource {
-	return &mrpb.MonitoredResource{
+	m := &mrpb.MonitoredResource{
 		Type: "k8s_container",
 		Labels: map[string]string{
 			"container_name": e.Resource["container.name"],
@@ -85,10 +91,17 @@ func k8sContainerResource(e *entry.Entry) *mrpb.MonitoredResource {
 			// TODO project id
 		},
 	}
+
+	delete(e.Resource, "container.name")
+	delete(e.Resource, "k8s.pod.name")
+	delete(e.Resource, "k8s.namespace.name")
+	delete(e.Resource, "k8s.cluster.name")
+
+	return m
 }
 
 func k8sNodeResource(e *entry.Entry) *mrpb.MonitoredResource {
-	return &mrpb.MonitoredResource{
+	m := &mrpb.MonitoredResource{
 		Type: "k8s_node",
 		Labels: map[string]string{
 			"cluster_name": e.Resource["k8s.cluster.name"],
@@ -96,24 +109,37 @@ func k8sNodeResource(e *entry.Entry) *mrpb.MonitoredResource {
 			// TODO project id
 		},
 	}
+
+	delete(e.Resource, "k8s.cluster.name")
+	delete(e.Resource, "host.name")
+
+	return m
 }
 
 func k8sClusterResource(e *entry.Entry) *mrpb.MonitoredResource {
-	return &mrpb.MonitoredResource{
+	m := &mrpb.MonitoredResource{
 		Type: "k8s_cluster",
 		Labels: map[string]string{
 			"cluster_name": e.Resource["k8s.cluster.name"],
 			// TODO project id
 		},
 	}
+
+	delete(e.Resource, "k8s.cluster.name")
+
+	return m
 }
 
 func genericNodeResource(e *entry.Entry) *mrpb.MonitoredResource {
-	return &mrpb.MonitoredResource{
+	m := &mrpb.MonitoredResource{
 		Type: "generic_node",
 		Labels: map[string]string{
 			"node_id": e.Resource["host.name"],
 			// TODO project id
 		},
 	}
+
+	delete(e.Resource, "host.name")
+
+	return m
 }


### PR DESCRIPTION
## Description of Changes

Some users would like to se the `location` resource for managed resource types (such as k8s_pod). We do not currently have a way to auto detect this field.

- added `Location` parameter, when not nil, the field will be set to the proto entry's `location` resource field and then deleted.
- make sure `newEntry.Labels` is not nil. If the resource type is not known, this map will be nil and cause a panic when resources are converted to labels [(we do this because google logging will remove any labels that do not map to a monitored resource type](https://github.com/observIQ/stanza/pull/425))
- added test cases for all supported monitored resource types and unknown resource type
- delete resources that were promoted to monitored resource type resources to prevent them from being merged into the entry's labels (duplication)

When an entry fulfills a monitored resource types requirements, the location field is added. For example, `generic_node`:
<img width="596" alt="Screen Shot 2021-09-21 at 1 50 10 PM" src="https://user-images.githubusercontent.com/23043836/134222576-ff5a1912-c4d6-44ef-9625-1c9b8ca50c16.png">

input:
```json
{"message":"api connection failed","region":"us-central4","log_type":"custom-app","host.name":"local-cluster"}
{"message":"fail"}
```

config:
```yaml
pipeline:
- type: file_input
  include:
  - ./in.json
  start_at: beginning

- type: json_parser

- type: move
  id: promote-host.name
  from: '$record["host.name"]'
  to: '$resource["host.name"]'

- type: move
  id: promote-log_type
  from: $record.log_type
  to: $labels.log_type

- type: move
  id: promote-region
  from: $record.region
  to: $labels.region
  output:
  - google_cloud_output
  - stdout

- type: stdout

- type: google_cloud_output
  location: $labels.region
  log_name_field: $labels.log_type
  credentials_file: ./creds.json
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
