### PR TITLE
Fixed a bug when flushing a range from the memory buffer

### DIFF
--- a/operator/buffer/memory.go
+++ b/operator/buffer/memory.go
@@ -195,7 +195,7 @@ func (mc *memoryClearer) MarkRangeAsFlushed(start, end uint) error {
 		delete(mc.buffer.inFlight, id)
 	}
 	mc.buffer.inFlightMux.Unlock()
-	mc.buffer.sem.Release(int64(end - start - 1))
+	mc.buffer.sem.Release(int64(end - start))
 	return nil
 }
 


### PR DESCRIPTION
## Description of Changes
- When flushing from a range, the memory buffer was subtracting an additional 1 before releasing resources from the underlying semaphore. This resulted in the memory buffer not reclaiming the correct amount of space after a flush. Instead, every flush would cause it to lose 1 capacity. Eventually, the semaphore will reach its max capacity and this will block all input operators from sending to the buffer, even though the buffer is empty. Unfortunately, when this happens, there are no logs to indicate the problem. Instead, it will appear as if there is no longer data to collect and/or stanza has stopped working.
- This behavior can be reproduced by using the google output operator with a severely reduced buffer size. Otherwise, it will takes much longer to reproduce this, since the default capacity is 1048576.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
