### PR TITLE
Windows Event Log fix for Windows Server 2022

### DIFF
--- a/operator/builtin/input/windows/bookmark.go
+++ b/operator/builtin/input/windows/bookmark.go
@@ -56,9 +56,9 @@ func (b *Bookmark) Render(buffer Buffer) (string, error) {
 	}
 
 	var bufferUsed, propertyCount uint32
-	err := evtRender(0, b.handle, EvtRenderBookmark, buffer.Size(), buffer.FirstByte(), &bufferUsed, &propertyCount)
+	err := evtRender(0, b.handle, EvtRenderBookmark, buffer.SizeBytes(), buffer.FirstByte(), &bufferUsed, &propertyCount)
 	if err == ErrorInsufficientBuffer {
-		buffer.UpdateSize(bufferUsed)
+		buffer.UpdateSizeBytes(bufferUsed)
 		return b.Render(buffer)
 	}
 

--- a/operator/builtin/input/windows/buffer.go
+++ b/operator/builtin/input/windows/buffer.go
@@ -20,15 +20,20 @@ type Buffer struct {
 	buffer []byte
 }
 
-// ReadBytes will read UTF-8 bytes from the buffer.
+// ReadBytes will read UTF-8 bytes from the buffer, where offset is the number of bytes to be read
 func (b *Buffer) ReadBytes(offset uint32) ([]byte, error) {
-	utf16 := b.buffer[:bytesPerWChar*offset]
+	utf16 := b.buffer[:offset]
 	utf8, err := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder().Bytes(utf16)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert buffer contents to utf8: %s", err)
 	}
 
 	return bytes.Trim(utf8, "\u0000"), nil
+}
+
+// ReadWideChars will read UTF-8 bytes from the buffer, where offset is the number of wchars to read
+func (b *Buffer) ReadWideChars(offset uint32) ([]byte, error) {
+	return b.ReadBytes(offset * bytesPerWChar)
 }
 
 // ReadString will read a UTF-8 string from the buffer.
@@ -40,13 +45,23 @@ func (b *Buffer) ReadString(offset uint32) (string, error) {
 	return string(bytes), nil
 }
 
-// UpdateSize will update the size of the buffer.
-func (b *Buffer) UpdateSize(size uint32) {
+// UpdateSizeBytes will update the size of the buffer to fit size bytes.
+func (b *Buffer) UpdateSizeBytes(size uint32) {
+	b.buffer = make([]byte, size)
+}
+
+// UpdateSizeWide will update the size of the buffer to fit size wchars.
+func (b *Buffer) UpdateSizeWide(size uint32) {
 	b.buffer = make([]byte, bytesPerWChar*size)
 }
 
-// Size will return the size of the buffer.
-func (b *Buffer) Size() uint32 {
+// SizeBytes will return the size of the buffer as number of bytes.
+func (b *Buffer) SizeBytes() uint32 {
+	return uint32(len(b.buffer))
+}
+
+// SizeWide returns the size of the buffer as number of wchars
+func (b *Buffer) SizeWide() uint32 {
 	return uint32(len(b.buffer) / bytesPerWChar)
 }
 

--- a/operator/builtin/input/windows/buffer.go
+++ b/operator/builtin/input/windows/buffer.go
@@ -11,6 +11,8 @@ import (
 
 // defaultBufferSize is the default size of the buffer.
 const defaultBufferSize = 16384
+
+// bytesPerWChar is the number bytes in a Windows wide character.
 const bytesPerWChar = 2
 
 // Buffer is a buffer of utf-16 bytes.

--- a/operator/builtin/input/windows/buffer.go
+++ b/operator/builtin/input/windows/buffer.go
@@ -11,6 +11,7 @@ import (
 
 // defaultBufferSize is the default size of the buffer.
 const defaultBufferSize = 16384
+const bytesPerWChar = 2
 
 // Buffer is a buffer of utf-16 bytes.
 type Buffer struct {
@@ -19,7 +20,7 @@ type Buffer struct {
 
 // ReadBytes will read UTF-8 bytes from the buffer.
 func (b *Buffer) ReadBytes(offset uint32) ([]byte, error) {
-	utf16 := b.buffer[:offset]
+	utf16 := b.buffer[:bytesPerWChar*offset]
 	utf8, err := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder().Bytes(utf16)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert buffer contents to utf8: %s", err)
@@ -39,12 +40,12 @@ func (b *Buffer) ReadString(offset uint32) (string, error) {
 
 // UpdateSize will update the size of the buffer.
 func (b *Buffer) UpdateSize(size uint32) {
-	b.buffer = make([]byte, size)
+	b.buffer = make([]byte, bytesPerWChar*size)
 }
 
 // Size will return the size of the buffer.
 func (b *Buffer) Size() uint32 {
-	return uint32(len(b.buffer))
+	return uint32(len(b.buffer) / bytesPerWChar)
 }
 
 // FirstByte will return a pointer to the first byte.

--- a/operator/builtin/input/windows/buffer_test.go
+++ b/operator/builtin/input/windows/buffer_test.go
@@ -16,7 +16,7 @@ func TestBufferReadBytes(t *testing.T) {
 	for i, b := range utf16 {
 		buffer.buffer[i] = b
 	}
-	offset := uint32(len(utf16))
+	offset := uint32(len(utf16) / 2)
 	bytes, err := buffer.ReadBytes(offset)
 	require.NoError(t, err)
 	require.Equal(t, utf8, bytes)
@@ -29,7 +29,7 @@ func TestBufferReadString(t *testing.T) {
 	for i, b := range utf16 {
 		buffer.buffer[i] = b
 	}
-	offset := uint32(len(utf16))
+	offset := uint32(len(utf16) / 2)
 	result, err := buffer.ReadString(offset)
 	require.NoError(t, err)
 	require.Equal(t, "test", result)
@@ -38,12 +38,12 @@ func TestBufferReadString(t *testing.T) {
 func TestBufferUpdateSize(t *testing.T) {
 	buffer := NewBuffer()
 	buffer.UpdateSize(1)
-	require.Equal(t, 1, len(buffer.buffer))
+	require.Equal(t, 1*bytesPerWChar, len(buffer.buffer))
 }
 
 func TestBufferSize(t *testing.T) {
 	buffer := NewBuffer()
-	require.Equal(t, uint32(defaultBufferSize), buffer.Size())
+	require.Equal(t, uint32(defaultBufferSize/bytesPerWChar), buffer.Size())
 }
 
 func TestBufferFirstByte(t *testing.T) {

--- a/operator/builtin/input/windows/buffer_test.go
+++ b/operator/builtin/input/windows/buffer_test.go
@@ -16,8 +16,21 @@ func TestBufferReadBytes(t *testing.T) {
 	for i, b := range utf16 {
 		buffer.buffer[i] = b
 	}
-	offset := uint32(len(utf16) / 2)
+	offset := uint32(len(utf16))
 	bytes, err := buffer.ReadBytes(offset)
+	require.NoError(t, err)
+	require.Equal(t, utf8, bytes)
+}
+
+func TestBufferReadWideBytes(t *testing.T) {
+	buffer := NewBuffer()
+	utf8 := []byte("test")
+	utf16, _ := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewEncoder().Bytes(utf8)
+	for i, b := range utf16 {
+		buffer.buffer[i] = b
+	}
+	offset := uint32(len(utf16) / 2)
+	bytes, err := buffer.ReadWideChars(offset)
 	require.NoError(t, err)
 	require.Equal(t, utf8, bytes)
 }
@@ -29,7 +42,7 @@ func TestBufferReadString(t *testing.T) {
 	for i, b := range utf16 {
 		buffer.buffer[i] = b
 	}
-	offset := uint32(len(utf16) / 2)
+	offset := uint32(len(utf16))
 	result, err := buffer.ReadString(offset)
 	require.NoError(t, err)
 	require.Equal(t, "test", result)
@@ -37,13 +50,24 @@ func TestBufferReadString(t *testing.T) {
 
 func TestBufferUpdateSize(t *testing.T) {
 	buffer := NewBuffer()
-	buffer.UpdateSize(1)
-	require.Equal(t, 1*bytesPerWChar, len(buffer.buffer))
+	buffer.UpdateSizeBytes(1)
+	require.Equal(t, 1, len(buffer.buffer))
+}
+
+func TestBufferUpdateSizeWide(t *testing.T) {
+	buffer := NewBuffer()
+	buffer.UpdateSizeWide(1)
+	require.Equal(t, 2, len(buffer.buffer))
 }
 
 func TestBufferSize(t *testing.T) {
 	buffer := NewBuffer()
-	require.Equal(t, uint32(defaultBufferSize/bytesPerWChar), buffer.Size())
+	require.Equal(t, uint32(defaultBufferSize), buffer.SizeBytes())
+}
+
+func TestBufferSizeWide(t *testing.T) {
+	buffer := NewBuffer()
+	require.Equal(t, uint32(defaultBufferSize/2), buffer.SizeWide())
 }
 
 func TestBufferFirstByte(t *testing.T) {

--- a/operator/builtin/input/windows/event.go
+++ b/operator/builtin/input/windows/event.go
@@ -18,9 +18,9 @@ func (e *Event) RenderSimple(buffer Buffer) (EventXML, error) {
 	}
 
 	var bufferUsed, propertyCount uint32
-	err := evtRender(0, e.handle, EvtRenderEventXML, buffer.Size(), buffer.FirstByte(), &bufferUsed, &propertyCount)
+	err := evtRender(0, e.handle, EvtRenderEventXML, buffer.SizeBytes(), buffer.FirstByte(), &bufferUsed, &propertyCount)
 	if err == ErrorInsufficientBuffer {
-		buffer.UpdateSize(bufferUsed)
+		buffer.UpdateSizeBytes(bufferUsed)
 		return e.RenderSimple(buffer)
 	}
 
@@ -43,17 +43,19 @@ func (e *Event) RenderFormatted(buffer Buffer, publisher Publisher) (EventXML, e
 	}
 
 	var bufferUsed uint32
-	err := evtFormatMessage(publisher.handle, e.handle, 0, 0, 0, EvtFormatMessageXML, buffer.Size(), buffer.FirstByte(), &bufferUsed)
+	err := evtFormatMessage(publisher.handle, e.handle, 0, 0, 0, EvtFormatMessageXML, buffer.SizeWide(), buffer.FirstByte(), &bufferUsed)
 	if err == ErrorInsufficientBuffer {
-		buffer.UpdateSize(bufferUsed)
+		buffer.UpdateSizeWide(bufferUsed)
 		return e.RenderFormatted(buffer, publisher)
 	}
 
 	if err != nil {
-		return EventXML{}, fmt.Errorf("syscall to 'EvtFormatMessage' failed: %s", err)
+		return EventXML{}, fmt.Errorf("syscall to 'EvtFormatMessage' failed: %w, params: (%x, %x, 0, 0, 0, %x, %x, %p, %p)",
+			err,
+			publisher.handle, e.handle, EvtFormatMessageXML, buffer.SizeWide(), buffer.FirstByte(), &bufferUsed)
 	}
 
-	bytes, err := buffer.ReadBytes(bufferUsed)
+	bytes, err := buffer.ReadWideChars(bufferUsed)
 	if err != nil {
 		return EventXML{}, fmt.Errorf("failed to read bytes from buffer: %s", err)
 	}

--- a/operator/builtin/input/windows/operator.go
+++ b/operator/builtin/input/windows/operator.go
@@ -98,7 +98,8 @@ func (e *EventLogInput) Start() error {
 
 	if offsetXML != "" {
 		if err := e.bookmark.Open(offsetXML); err != nil {
-			return fmt.Errorf("failed to open bookmark: %s", err)
+			e.Errorf("Failed to open bookmark, continuing without previous bookmark: %s", err)
+			e.offsets.Set(e.channel, []byte{})
 		}
 	}
 

--- a/operator/builtin/input/windows/operator.go
+++ b/operator/builtin/input/windows/operator.go
@@ -100,6 +100,9 @@ func (e *EventLogInput) Start() error {
 		if err := e.bookmark.Open(offsetXML); err != nil {
 			e.Errorf("Failed to open bookmark, continuing without previous bookmark: %s", err)
 			e.offsets.Set(e.channel, []byte{})
+			if err := e.Sync(); err != nil {
+				return fmt.Errorf("Could not sync empty bookmark to offsets database: %s", err)
+			}
 		}
 	}
 

--- a/operator/builtin/input/windows/xml.go
+++ b/operator/builtin/input/windows/xml.go
@@ -90,7 +90,7 @@ func (e *EventXML) parseMessage() (string, map[string]interface{}) {
 func unmarshalEventXML(bytes []byte) (EventXML, error) {
 	var eventXML EventXML
 	if err := xml.Unmarshal(bytes, &eventXML); err != nil {
-		return EventXML{}, fmt.Errorf("failed to unmarshal xml bytes into event: %s", err)
+		return EventXML{}, fmt.Errorf("failed to unmarshal xml bytes into event: %w (%s)", err, string(bytes))
 	}
 	return eventXML, nil
 }


### PR DESCRIPTION
## Description of Changes
In the windows event log operator, Windows server 2022 was having some trouble parsing XML in this function [here](https://github.com/observIQ/stanza/blob/bf1f5b074a0fc4b48f96f4079531577bf194ecf3/operator/builtin/input/windows/event.go#L40))

If we look at the [documentation for EvtFormatMessage](https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage), we can see that BufferUsed indicates the amount of characters used, not the number of bytes. Since the buffer is of type LPWSTR, this is a wide-character string, meaning each character is 2 bytes.

We did not encounter this issue previously, because it seems like Windows previously over-reported the amount of characters written to the buffer:
```
buffer.Size(): 8192, bufferUsed: 2300
Output: 
<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Service Control Manager' Guid='{555908d1-a6d7-4695-8e1e-26931d2012f4}' EventSourceName='Service Control Manager'/><EventID Qualifiers='49152'>7000</EventID><Version>0</Version><Level>2</Level><Task>0</Task><Opcode>0</Opcode><Keywords>0x8080000000000000</Keywords><TimeCreated SystemTime='2021-09-29T18:09:24.9270059Z'/><EventRecordID>5485</EventRecordID><Correlation/><Execution ProcessID='1140' ThreadID='2032'/><Channel>System</Channel><Computer>DESKTOP-RHHPJ19</Computer><Security/></System><EventData><Data Name='param1'>observiq-collector</Data><Data Name='param2'>%%2</Data><Binary>6F0062007300650072007600690071002D0063006F006C006C006500630074006F0072000000</Binary></EventData><RenderingInfo Culture='en-US'><Message>The observiq-collector service failed to start due to the following error:
The system cannot find the file specified.</Message><Level>Error</Level><Task></Task><Opcode></Opcode><Channel></Channel><Provider>Microsoft-Windows-Service Control Manager</Provider><Keywords><Keyword>Classic</Keyword></Keywords></RenderingInfo></Event>
```

Above, we can see that the reported number of characters written to the buffer was 2300, but if you count the number of characters, you'll see that there were really only 1146, less than half.

Also made a change so that if the saved bookmark can't be parsed, we continue without it instead of refusing to start up.

This change has been tested and confirmed to work on:
* Microsoft Windows Server 2022 Datacenter
* Microsoft Windows Server 2012
* Microsoft Windows Server 2019
* Microsoft Windows 10 Pro

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
