### PR TITLE
windows_event operator: Fix incorrect Sync call

### DIFF
--- a/operator/builtin/input/windows/operator.go
+++ b/operator/builtin/input/windows/operator.go
@@ -100,7 +100,7 @@ func (e *EventLogInput) Start() error {
 		if err := e.bookmark.Open(offsetXML); err != nil {
 			e.Errorf("Failed to open bookmark, continuing without previous bookmark: %s", err)
 			e.offsets.Set(e.channel, []byte{})
-			if err := e.Sync(); err != nil {
+			if err := e.offsets.Sync(); err != nil {
 				return fmt.Errorf("Could not sync empty bookmark to offsets database: %s", err)
 			}
 		}


### PR DESCRIPTION
## Description of Changes
* Changed call of logger Sync to intended Persister Sync call

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
