### PR TITLE
enable tls explicitly

### DIFF
--- a/operator/builtin/input/http/config.go
+++ b/operator/builtin/input/http/config.go
@@ -160,6 +160,7 @@ func (c HTTPInputConfig) build(context operator.BuildContext) (*HTTPInput, error
 
 	httpInput := &HTTPInput{
 		InputOperator: inputOperator,
+		tls:           c.TLS.Enable,
 		server: http.Server{
 			Addr: c.ListenAddress,
 			// #nosec - User to specify tls minimum version

--- a/operator/builtin/input/http/operator.go
+++ b/operator/builtin/input/http/operator.go
@@ -25,6 +25,7 @@ func init() {
 type HTTPInput struct {
 	helper.InputOperator
 
+	tls         bool
 	server      http.Server
 	json        jsoniter.API
 	maxBodySize int64
@@ -84,10 +85,18 @@ func (t *HTTPInput) goListen(ctx context.Context) {
 	go func() {
 		defer t.wg.Done()
 		t.Debugf("Starting http server on socket %s", t.server.Addr)
-		if err := t.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			t.Errorf("http server failed: %s", err)
-			return
+		if t.tls {
+			if err := t.server.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+				t.Errorf("http server failed: %s", err)
+				return
+			}
+		} else {
+			if err := t.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				t.Errorf("http server failed: %s", err)
+				return
+			}
 		}
+
 		t.Debugf("Http server shutdown finished")
 	}()
 }


### PR DESCRIPTION
## Description of Changes

When using TLS, net.listener needs to be used with server.Serve or we need to use [ListenAndServeTLS](https://pkg.go.dev/net/http#Server.ListenAndServeTLS)

This PR passes tls.Enable to the operator so it can decide if tls should be used or not, as ListenAndServe does not perform this detection.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
