### PR TITLE
Ensure xml_parser emits structure that passes type assertion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ install-tools:
 	cd $(TOOLS_MOD_DIR) && go install github.com/uw-labs/lichen
 	cd $(TOOLS_MOD_DIR) && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment
 	cd $(TOOLS_MOD_DIR) && go install github.com/observiq/amazon-log-agent-benchmark-tool/cmd/logbench
+	cd $(TOOLS_MOD_DIR) && go install github.com/securego/gosec/v2/cmd/gosec@v2.8.1
 
 .PHONY: scan-license
 scan-license: build-all
@@ -77,6 +78,10 @@ vet: check-missing-modules
 	GOOS=darwin $(MAKE) for-all CMD="go vet ./..."
 	GOOS=linux $(MAKE) for-all CMD="go vet ./..."
 	GOOS=windows $(MAKE) for-all CMD="go vet ./..."
+
+.PHONY: secure
+secure:
+	gosec ./...
 
 .PHONY: check-missing-modules
 check-missing-modules:

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	google.golang.org/api v0.52.0
 	google.golang.org/genproto v0.0.0-20210722135532-667f2b7c528f
 	google.golang.org/grpc v1.40.0
+	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0
 	// k8s.io modules should be the same version
 	k8s.io/api v0.22.2
@@ -111,7 +112,6 @@ require (
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/klog/v2 v2.9.0 // indirect

--- a/operator/builtin/parser/xml/element.go
+++ b/operator/builtin/parser/xml/element.go
@@ -9,7 +9,7 @@ import (
 type Element struct {
 	Tag        string
 	Content    string
-	Attributes map[string]string
+	Attributes map[string]interface{}
 	Children   []*Element
 	Parent     *Element
 }
@@ -53,12 +53,12 @@ func newElement(element xml.StartElement) *Element {
 }
 
 // getAttributes returns the attributes of the given element
-func getAttributes(element xml.StartElement) map[string]string {
+func getAttributes(element xml.StartElement) map[string]interface{} {
 	if len(element.Attr) == 0 {
 		return nil
 	}
 
-	attributes := map[string]string{}
+	attributes := map[string]interface{}{}
 	for _, attr := range element.Attr {
 		key := attr.Name.Local
 		attributes[key] = attr.Value

--- a/operator/builtin/parser/xml/xml_test.go
+++ b/operator/builtin/parser/xml/xml_test.go
@@ -66,7 +66,7 @@ func TestParse(t *testing.T) {
 			value: "<person age='30'>Jon Smith</person>",
 			expectedResult: map[string]interface{}{
 				"tag": "person",
-				"attributes": map[string]string{
+				"attributes": map[string]interface{}{
 					"age": "30",
 				},
 				"content": "Jon Smith",
@@ -78,7 +78,7 @@ func TestParse(t *testing.T) {
 			strict: &strictDisabled,
 			expectedResult: map[string]interface{}{
 				"tag": "person",
-				"attributes": map[string]string{
+				"attributes": map[string]interface{}{
 					"company": "at&t",
 				},
 				"content": "Jon Smith",
@@ -90,14 +90,14 @@ func TestParse(t *testing.T) {
 			expectedResult: []map[string]interface{}{
 				{
 					"tag": "person",
-					"attributes": map[string]string{
+					"attributes": map[string]interface{}{
 						"age": "30",
 					},
 					"content": "Jon Smith",
 				},
 				{
 					"tag": "person",
-					"attributes": map[string]string{
+					"attributes": map[string]interface{}{
 						"age": "28",
 					},
 					"content": "Sally Smith",
@@ -115,7 +115,7 @@ func TestParse(t *testing.T) {
 						"children": []map[string]interface{}{
 							{
 								"tag": "person",
-								"attributes": map[string]string{
+								"attributes": map[string]interface{}{
 									"age": "30",
 								},
 								"content": "Jon Smith",


### PR DESCRIPTION
## Description of Changes
The xml_parser was emitting a `map[string]string`, which was missed in type assertions made by the `entry.Field` implementations. Really, the `entry.Field` implementations should be more robust, but this is a quick fix for the issue.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
