### PR TITLE
Refactored buffer interface to remove drain in favor of a close that …

### DIFF
--- a/operator/buffer/buffer.go
+++ b/operator/buffer/buffer.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
-	"github.com/open-telemetry/opentelemetry-log-collection/operator"
 )
 
 // Buffer is an interface for an entry buffer
@@ -19,11 +18,9 @@ type Buffer interface {
 	// Read can be a blocking call depending on the underlying implementation.
 	Read(context.Context) ([]*entry.Entry, error)
 
-	// Drain drains all contents currently in the buffer to the returned entry
-	Drain(context.Context) ([]*entry.Entry, error)
-
-	// Close runs cleanup code for buffer
-	Close() error
+	// Close runs cleanup code for buffer and may return entries left in the buffer
+	// depending on the underlying implementation
+	Close() ([]*entry.Entry, error)
 }
 
 // Config is a struct that wraps a Builder
@@ -40,7 +37,7 @@ func NewConfig() Config {
 
 // Builder builds a Buffer given build context
 type Builder interface {
-	Build(context operator.BuildContext, pluginID string) (Buffer, error)
+	Build(operatorID string) (Buffer, error)
 }
 
 // UnmarshalJSON unmarshals JSON

--- a/operator/buffer/disk.go
+++ b/operator/buffer/disk.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
-	"github.com/open-telemetry/opentelemetry-log-collection/operator"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
 )
 
@@ -42,7 +41,7 @@ func NewDiskBufferConfig() *DiskBufferConfig {
 }
 
 // Build creates a new Buffer from a DiskBufferConfig
-func (c DiskBufferConfig) Build(context operator.BuildContext, _ string) (Buffer, error) {
+func (c DiskBufferConfig) Build(operatorID string) (Buffer, error) {
 	return &DiskBuffer{}, nil
 }
 
@@ -62,12 +61,7 @@ func (m *DiskBuffer) Read(ctx context.Context) ([]*entry.Entry, error) {
 	return nil, nil
 }
 
-// Drain drains all contents currently in the buffer to the returned entry
-func (m *DiskBuffer) Drain(ctx context.Context) ([]*entry.Entry, error) {
-	return nil, nil
-}
-
 // Close runs cleanup code for buffer
-func (m *DiskBuffer) Close() error {
-	return nil
+func (m *DiskBuffer) Close() ([]*entry.Entry, error) {
+	return nil, nil
 }

--- a/operator/buffer/memory.go
+++ b/operator/buffer/memory.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
-	"github.com/open-telemetry/opentelemetry-log-collection/operator"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
 )
 
@@ -31,7 +30,7 @@ func NewMemoryBufferConfig() *MemoryBufferConfig {
 
 // Build builds a MemoryBufferConfig into a Buffer, loading any entries that were previously unflushed
 // back into memory
-func (c MemoryBufferConfig) Build(context operator.BuildContext, pluginID string) (Buffer, error) {
+func (c MemoryBufferConfig) Build(operatorID string) (Buffer, error) {
 	return &MemoryBuffer{}, nil
 }
 
@@ -50,15 +49,10 @@ func (m *MemoryBuffer) Add(ctx context.Context, e *entry.Entry) error {
 // Read reads from the buffer.
 // Read will block until the there are MaxChunkSize entries or we have block as long as MachChunkDelay.
 func (m *MemoryBuffer) Read(ctx context.Context) ([]*entry.Entry, error) {
-	return nil, nil
-}
-
-// Drain drains all contents currently in the buffer to the returned entry
-func (m *MemoryBuffer) Drain(ctx context.Context) ([]*entry.Entry, error) {
-	return nil, nil
+	return []*entry.Entry{}, nil
 }
 
 // Close runs cleanup code for buffer
-func (m *MemoryBuffer) Close() error {
-	return nil
+func (m *MemoryBuffer) Close() ([]*entry.Entry, error) {
+	return []*entry.Entry{}, nil
 }

--- a/operator/builtin/output/elastic/elastic.go
+++ b/operator/builtin/output/elastic/elastic.go
@@ -71,7 +71,7 @@ func (c ElasticOutputConfig) Build(bc operator.BuildContext) ([]operator.Operato
 		)
 	}
 
-	buffer, err := c.BufferConfig.Build(bc, c.ID())
+	buffer, err := c.BufferConfig.Build(c.ID())
 	if err != nil {
 		return nil, err
 	}
@@ -125,8 +125,9 @@ func (e *ElasticOutput) Stop() error {
 	e.cancel()
 	e.wg.Wait()
 	e.flusher.Stop()
-	// TODO handle buffer drain
-	return e.buffer.Close()
+	// TODO handle buffer close entries
+	_, err := e.buffer.Close()
+	return err
 }
 
 // Process adds an entry to the outputs buffer

--- a/operator/builtin/output/forward/forward.go
+++ b/operator/builtin/output/forward/forward.go
@@ -45,7 +45,7 @@ func (c ForwardOutputConfig) Build(bc operator.BuildContext) ([]operator.Operato
 		return nil, err
 	}
 
-	buffer, err := c.BufferConfig.Build(bc, c.ID())
+	buffer, err := c.BufferConfig.Build(c.ID())
 	if err != nil {
 		return nil, err
 	}
@@ -101,8 +101,9 @@ func (f *ForwardOutput) Stop() error {
 	f.cancel()
 	f.wg.Wait()
 	f.flusher.Stop()
-	// TODO handle buffer Drain
-	return f.buffer.Close()
+	// TODO handle buffer close entries
+	_, err := f.buffer.Close()
+	return err
 }
 
 // Process adds an entry to the outputs buffer

--- a/operator/builtin/output/googlecloud/google_cloud.go
+++ b/operator/builtin/output/googlecloud/google_cloud.go
@@ -66,7 +66,7 @@ func (c GoogleCloudOutputConfig) Build(bc operator.BuildContext) ([]operator.Ope
 		return nil, err
 	}
 
-	newBuffer, err := c.BufferConfig.Build(bc, c.ID())
+	newBuffer, err := c.BufferConfig.Build(c.ID())
 	if err != nil {
 		return nil, err
 	}
@@ -196,8 +196,9 @@ func (g *GoogleCloudOutput) Stop() error {
 	g.cancel()
 	g.wg.Wait()
 	g.flusher.Stop()
-	// TODO handle buffer Drain
-	if err := g.buffer.Close(); err != nil {
+	// TODO handle buffer close entries
+	_, err := g.buffer.Close()
+	if err != nil {
 		return err
 	}
 	if g.client != nil {

--- a/operator/builtin/output/newrelic/newrelic.go
+++ b/operator/builtin/output/newrelic/newrelic.go
@@ -62,7 +62,7 @@ func (c NewRelicOutputConfig) Build(bc operator.BuildContext) ([]operator.Operat
 		return nil, err
 	}
 
-	buffer, err := c.BufferConfig.Build(bc, c.ID())
+	buffer, err := c.BufferConfig.Build(c.ID())
 	if err != nil {
 		return nil, err
 	}
@@ -145,8 +145,9 @@ func (nro *NewRelicOutput) Stop() error {
 	nro.cancel()
 	nro.wg.Wait()
 	nro.flusher.Stop()
-	// TODO deal with buffer Drain
-	return nro.buffer.Close()
+	// TODO handle buffer close entries
+	_, err := nro.buffer.Close()
+	return err
 }
 
 // Process adds an entry to the output's buffer


### PR DESCRIPTION
## Description of Changes
- Removed `Drain` from buffer interface in favor of `Close` that could return entries. `Drain` doesn't make sense for a disk buffer implementation and implies something will be returned. `Close` on the other hand makes it up to the implementation what it returns as far as entries go.
- Removed the `operator.BuildContext` from the buffer builder interface

**Note**: Output operator tests are failing as they need a valid memory buffer. This will be fixed in a following PR

## **Please check that the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
~~ - [ ] Docs have been added / updated (for bug fixes / features)~~
~~- [ ] Add a changelog entry (for non-trivial bug fixes / features)~~
~~- [ ] CI passes~~ (Known will fail)
