### PR TITLE
Removed operatorID from buffer builder interface

### DIFF
--- a/operator/buffer/buffer.go
+++ b/operator/buffer/buffer.go
@@ -41,7 +41,7 @@ func NewConfig() Config {
 
 // Builder builds a Buffer given build context
 type Builder interface {
-	Build(operatorID string) (Buffer, error)
+	Build() (Buffer, error)
 }
 
 // UnmarshalJSON unmarshals JSON

--- a/operator/buffer/disk.go
+++ b/operator/buffer/disk.go
@@ -41,7 +41,7 @@ func NewDiskBufferConfig() *DiskBufferConfig {
 }
 
 // Build creates a new Buffer from a DiskBufferConfig
-func (c DiskBufferConfig) Build(operatorID string) (Buffer, error) {
+func (c DiskBufferConfig) Build() (Buffer, error) {
 	return &DiskBuffer{}, nil
 }
 

--- a/operator/buffer/memory.go
+++ b/operator/buffer/memory.go
@@ -31,9 +31,8 @@ func NewMemoryBufferConfig() *MemoryBufferConfig {
 }
 
 // Build builds a MemoryBufferConfig into a Buffer
-func (c MemoryBufferConfig) Build(operatorID string) (Buffer, error) {
+func (c MemoryBufferConfig) Build() (Buffer, error) {
 	return &MemoryBuffer{
-		operatorID:    operatorID,
 		buf:           make(chan *entry.Entry, c.MaxEntries),
 		maxChunkDelay: c.MaxChunkDelay.Raw(),
 		maxChunkSize:  c.MaxChunkSize,
@@ -43,7 +42,6 @@ func (c MemoryBufferConfig) Build(operatorID string) (Buffer, error) {
 
 // MemoryBuffer is a buffer that holds all entries in memory until Close() is called.
 type MemoryBuffer struct {
-	operatorID    string
 	buf           chan *entry.Entry
 	maxChunkDelay time.Duration
 	maxChunkSize  uint

--- a/operator/buffer/memory_test.go
+++ b/operator/buffer/memory_test.go
@@ -13,14 +13,12 @@ import (
 
 func TestMemoryBufferBuild(t *testing.T) {
 	cfg := NewMemoryBufferConfig()
-	operatorID := "operator"
 
-	buffer, err := cfg.Build(operatorID)
+	buffer, err := cfg.Build()
 	require.NoError(t, err)
 	require.IsType(t, &MemoryBuffer{}, buffer)
 
 	memBuffer := buffer.(*MemoryBuffer)
-	assert.Equal(t, operatorID, memBuffer.operatorID)
 	assert.Equal(t, cfg.MaxChunkDelay.Raw(), memBuffer.maxChunkDelay)
 	assert.Equal(t, cfg.MaxChunkSize, memBuffer.maxChunkSize)
 	assert.False(t, memBuffer.closed)
@@ -36,7 +34,7 @@ func TestMemoryBufferAdd(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				t.Parallel()
 				cfg := NewMemoryBufferConfig()
-				buffer, err := cfg.Build("operatorID")
+				buffer, err := cfg.Build()
 				require.NoError(t, err)
 
 				// Close buffer
@@ -55,7 +53,7 @@ func TestMemoryBufferAdd(t *testing.T) {
 				cfg := NewMemoryBufferConfig()
 				// Max entries 0 for a non buffered channel
 				cfg.MaxEntries = 0
-				buffer, err := cfg.Build("operatorID")
+				buffer, err := cfg.Build()
 				require.NoError(t, err)
 
 				// Create a context with a deadline
@@ -88,7 +86,7 @@ func TestMemoryBufferAdd(t *testing.T) {
 				t.Parallel()
 				cfg := NewMemoryBufferConfig()
 				// Max entries 0 for a non buffered channel
-				buffer, err := cfg.Build("operatorID")
+				buffer, err := cfg.Build()
 				require.NoError(t, err)
 
 				err = buffer.Add(context.Background(), &entry.Entry{})
@@ -115,7 +113,7 @@ func TestMemoryBufferRead(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				t.Parallel()
 				cfg := NewMemoryBufferConfig()
-				buffer, err := cfg.Build("operatorID")
+				buffer, err := cfg.Build()
 				require.NoError(t, err)
 
 				// Close buffer
@@ -134,7 +132,7 @@ func TestMemoryBufferRead(t *testing.T) {
 				cfg := NewMemoryBufferConfig()
 				// Create a large duration to ensure we never hit it
 				cfg.MaxChunkDelay = helper.NewDuration(20 * time.Minute)
-				buffer, err := cfg.Build("operatorID")
+				buffer, err := cfg.Build()
 				require.NoError(t, err)
 
 				// Create a context with a deadline
@@ -170,7 +168,7 @@ func TestMemoryBufferRead(t *testing.T) {
 				cfg.MaxChunkDelay = helper.NewDuration(20 * time.Minute)
 				// Ensure max chunk size is large enough we won't hit it
 				cfg.MaxChunkSize = 2
-				buffer, err := cfg.Build("operatorID")
+				buffer, err := cfg.Build()
 				require.NoError(t, err)
 
 				// Add two entries to buffer
@@ -211,7 +209,7 @@ func TestMemoryBufferRead(t *testing.T) {
 				cfg.MaxChunkDelay = helper.NewDuration(1 * time.Second)
 				// Ensure max chunk size is large enough we won't hit it
 				cfg.MaxChunkSize = 20
-				buffer, err := cfg.Build("operatorID")
+				buffer, err := cfg.Build()
 				require.NoError(t, err)
 
 				// Add single entry to buffer
@@ -259,7 +257,7 @@ func TestMemoryBufferClose(t *testing.T) {
 
 				cfg := NewMemoryBufferConfig()
 				// Max entries 0 for a non buffered channel
-				buffer, err := cfg.Build("operatorID")
+				buffer, err := cfg.Build()
 				require.NoError(t, err)
 
 				// Add to buffer to ensure it is drained
@@ -281,7 +279,7 @@ func TestMemoryBufferClose(t *testing.T) {
 				t.Parallel()
 
 				cfg := NewMemoryBufferConfig()
-				buffer, err := cfg.Build("operatorID")
+				buffer, err := cfg.Build()
 				require.NoError(t, err)
 
 				_, err = buffer.Close()

--- a/operator/builtin/output/elastic/elastic.go
+++ b/operator/builtin/output/elastic/elastic.go
@@ -71,7 +71,7 @@ func (c ElasticOutputConfig) Build(bc operator.BuildContext) ([]operator.Operato
 		)
 	}
 
-	buffer, err := c.BufferConfig.Build(c.ID())
+	buffer, err := c.BufferConfig.Build()
 	if err != nil {
 		return nil, err
 	}

--- a/operator/builtin/output/forward/forward.go
+++ b/operator/builtin/output/forward/forward.go
@@ -46,7 +46,7 @@ func (c ForwardOutputConfig) Build(bc operator.BuildContext) ([]operator.Operato
 		return nil, err
 	}
 
-	buffer, err := c.BufferConfig.Build(c.ID())
+	buffer, err := c.BufferConfig.Build()
 	if err != nil {
 		return nil, err
 	}

--- a/operator/builtin/output/googlecloud/google_cloud.go
+++ b/operator/builtin/output/googlecloud/google_cloud.go
@@ -67,7 +67,7 @@ func (c GoogleCloudOutputConfig) Build(bc operator.BuildContext) ([]operator.Ope
 		return nil, err
 	}
 
-	newBuffer, err := c.BufferConfig.Build(c.ID())
+	newBuffer, err := c.BufferConfig.Build()
 	if err != nil {
 		return nil, err
 	}

--- a/operator/builtin/output/newrelic/newrelic.go
+++ b/operator/builtin/output/newrelic/newrelic.go
@@ -63,7 +63,7 @@ func (c NewRelicOutputConfig) Build(bc operator.BuildContext) ([]operator.Operat
 		return nil, err
 	}
 
-	buffer, err := c.BufferConfig.Build(c.ID())
+	buffer, err := c.BufferConfig.Build()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description of Changes
Removed `operatorID` from `Build` on `Builder` interface. This isn't used in any of the new versions of the buffer implementation.

## **Please check that the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
~~- [ ] Add a changelog entry (for non-trivial bug fixes / features)~~ (part of larger v2 changelog)
- [ ] CI passes
