### PR TITLE
Fixed config file being able to be a glob path.

### DIFF
--- a/cmd/stanza/graph.go
+++ b/cmd/stanza/graph.go
@@ -31,7 +31,7 @@ func runGraph(_ *cobra.Command, _ []string, flags *RootFlags) {
 		_ = logger.Sync()
 	}()
 
-	cfg, err := agent.NewConfigFromGlobs([]string{flags.ConfigFile})
+	cfg, err := agent.NewConfigFromFile(flags.ConfigFile)
 	if err != nil {
 		logger.Errorw("Failed to read configs from glob", zap.Any("error", err))
 		os.Exit(1)

--- a/service/builder_test.go
+++ b/service/builder_test.go
@@ -103,7 +103,7 @@ func TestBuilder_validateNonGlobConfig(t *testing.T) {
 		{
 			desc: "configFile bad pattern",
 			testFunc: func(t *testing.T) {
-				builder := NewBuilder().WithConfigFile(`\/';*13vas`)
+				builder := NewBuilder().WithConfigFile(`[`)
 				err := builder.validateNonGlobConfig()
 				assert.ErrorIs(t, err, filepath.ErrBadPattern)
 			},

--- a/service/builder_test.go
+++ b/service/builder_test.go
@@ -1,9 +1,13 @@
 package service
 
 import (
+	"io/ioutil"
+	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -80,5 +84,61 @@ func TestBuilder(t *testing.T) {
 			tc.buildFunc(builder)
 			assert.Equal(t, tc.expected, builder)
 		})
+	}
+}
+
+func TestBuilder_validateNonGlobConfig(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		testFunc func(*testing.T)
+	}{
+		{
+			desc: "Nil configFile pointer",
+			testFunc: func(t *testing.T) {
+				builder := NewBuilder()
+				err := builder.validateNonGlobConfig()
+				assert.NoError(t, err)
+			},
+		},
+		{
+			desc: "configFile bad pattern",
+			testFunc: func(t *testing.T) {
+				builder := NewBuilder().WithConfigFile(`\/';*13vas`)
+				err := builder.validateNonGlobConfig()
+				assert.ErrorIs(t, err, filepath.ErrBadPattern)
+			},
+		},
+		{
+			desc: "configFile glob pattern",
+			testFunc: func(t *testing.T) {
+				// Create mock up file system
+				tmpDir := t.TempDir()
+				for i := 0; i < 3; i++ {
+					_, err := ioutil.TempFile(tmpDir, "config")
+					require.NoError(t, err)
+				}
+
+				builder := NewBuilder().WithConfigFile(path.Join(tmpDir, "config*"))
+				err := builder.validateNonGlobConfig()
+				assert.Error(t, err)
+			},
+		},
+		{
+			desc: "configFile single file",
+			testFunc: func(t *testing.T) {
+				// Create mock up file system
+				tmpDir := t.TempDir()
+				tmpFile, err := ioutil.TempFile(tmpDir, "config")
+				require.NoError(t, err)
+
+				builder := NewBuilder().WithConfigFile(path.Join(tmpDir, tmpFile.Name()))
+				err = builder.validateNonGlobConfig()
+				assert.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, tc.testFunc)
 	}
 }

--- a/service/builder_test.go
+++ b/service/builder_test.go
@@ -114,8 +114,10 @@ func TestBuilder_validateNonGlobConfig(t *testing.T) {
 				// Create mock up file system
 				tmpDir := t.TempDir()
 				for i := 0; i < 3; i++ {
-					_, err := ioutil.TempFile(tmpDir, "config")
+					tmpFile, err := ioutil.TempFile(tmpDir, "config")
 					require.NoError(t, err)
+					// Close the file right away as we don't need it open
+					tmpFile.Close()
 				}
 
 				builder := NewBuilder().WithConfigFile(path.Join(tmpDir, "config*"))
@@ -130,6 +132,8 @@ func TestBuilder_validateNonGlobConfig(t *testing.T) {
 				tmpDir := t.TempDir()
 				tmpFile, err := ioutil.TempFile(tmpDir, "config")
 				require.NoError(t, err)
+				// Close the file right away as we don't need it open
+				tmpFile.Close()
 
 				builder := NewBuilder().WithConfigFile(path.Join(tmpDir, tmpFile.Name()))
 				err = builder.validateNonGlobConfig()


### PR DESCRIPTION
## Description of Changes
If a glob path is sent in for a config file an error will be returned. We only want to support a single config file.

## **Please check that the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
~~- [ ] Add a changelog entry (for non-trivial bug fixes / features)~~ (larger v2 changelog)
- [ ] CI passes
