### PR TITLE
Add Native darwin arm64 compiled binaries to github releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added Native compiled artifact for Darwin amd64 [PR505]
+
 ### Added
 
 - Added agent log file rotation [PR488](https://github.com/observIQ/stanza/pull/488)

--- a/Makefile
+++ b/Makefile
@@ -110,11 +110,15 @@ install:
 	(cd ./cmd/stanza && CGO_ENABLED=0 go install .)
 
 .PHONY: build-all
-build-all: build-darwin-amd64 build-linux-amd64 build-linux-arm64 build-windows-amd64
+build-all: build-darwin-amd64 build-darwin-arm64 build-linux-amd64 build-linux-arm64 build-windows-amd64
 
 .PHONY: build-darwin-amd64
 build-darwin-amd64:
 	@GOOS=darwin GOARCH=amd64 $(MAKE) build
+
+.PHONY: build-darwin-amd64
+build-darwin-arm64:
+	@GOOS=darwin GOARCH=arm64 $(MAKE) build
 
 .PHONY: build-linux-amd64
 build-linux-amd64:

--- a/scripts/unix-install.sh
+++ b/scripts/unix-install.sh
@@ -262,7 +262,7 @@ set_os_arch()
 {
   os_arch=$(uname -m)
   case "$os_arch" in 
-    arm64e)
+    arm64)
       os_arch="arm64"
       ;;
     x86_64)
@@ -400,7 +400,7 @@ os_arch_check()
   info "Checking for valid operating system architecture..."
   arch=$(uname -m)
   case "$arch" in 
-    x86_64|arm64e)
+    x86_64|arm64)
       succeeded
       ;;
     *)


### PR DESCRIPTION
## Description of Changes

Since Go 1.16 we can natively compile stanza to be run on Apple silicon rather than letting Rosetta translate the instructions. This should add it to the release objects on Github for releases and allow the install script to determine whether to properly install the native binary. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
