### PR TITLE
Updated scan license github action to latest go version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ executors:
       xcode: 11.4.1
 
 jobs:
-
   build:
     executor: golang
     steps:
@@ -201,7 +200,7 @@ jobs:
           name: Run Unit Tests
           command: make test
       - codecov/upload:
-          file: '**/coverage.txt'
+          file: "**/coverage.txt"
 
   #test-linux-arm64:
   #  machine:
@@ -250,10 +249,11 @@ jobs:
 
     steps:
       - checkout
-      - run:
-          name: Upgrade Golang
-          shell: powershell.exe
-          command: choco upgrade golang --version=1.17
+      # Windows boxes now come with Go 1.17.6 installed https://circleci.com/docs/2.0/hello-world-windows/#software-pre-installed-in-the-windows-image
+      # - run:
+      #     name: Upgrade Golang
+      #     shell: powershell.exe
+      #     command: choco upgrade golang --version=1.17
       - run:
           name: Install GCC
           shell: powershell.exe
@@ -343,7 +343,8 @@ jobs:
 
       - run:
           name: Setup VM Workspace
-          command: gcloud compute ssh << parameters.instance >> --ssh-key-file=~/.ssh/key --ssh-flag="-o LogLevel=QUIET" -- 'mkdir -p ~/benchmark/out' &&
+          command:
+            gcloud compute ssh << parameters.instance >> --ssh-key-file=~/.ssh/key --ssh-flag="-o LogLevel=QUIET" -- 'mkdir -p ~/benchmark/out' &&
             gcloud compute scp --ssh-key-file=~/.ssh/key ./bin/stanza << parameters.instance >>:~/benchmark/ &&
             gcloud compute scp --ssh-key-file=~/.ssh/key ./bin/logbench << parameters.instance >>:~/benchmark/ &&
             gcloud compute scp --ssh-key-file=~/.ssh/key ./.circleci/testdata/benchmark.yaml << parameters.instance >>:~/benchmark/config.yaml &&

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: Install License Scanner
-        run: go install github.com/uw-labs/lichen@latest
+        run: go install github.com/uw-labs/lichen@v0.1.4
 
       - name: Check out source code
         uses: actions/checkout@v1


### PR DESCRIPTION
## Description of Changes
 Updated scan license github action to use go 1.17 and lock the dependency to an issue.


## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
