### PR TITLE
Forward buffer

### DIFF
--- a/operator/builtin/output/forward/forward.go
+++ b/operator/builtin/output/forward/forward.go
@@ -103,7 +103,7 @@ func (f *ForwardOutput) Stop() error {
 	f.cancel()
 	f.wg.Wait()
 	f.flusher.Stop()
-	// TODO handle buffer close entries
+
 	entries, err := f.buffer.Close()
 	if err != nil {
 		f.Errorf("Failed to retreive entries")

--- a/operator/builtin/output/forward/forward_test.go
+++ b/operator/builtin/output/forward/forward_test.go
@@ -23,6 +23,7 @@ func TestForwardOutput(t *testing.T) {
 		body, _ := ioutil.ReadAll(req.Body)
 		received <- body
 	}))
+	defer srv.Close()
 
 	cfg := NewForwardOutputConfig("test")
 	memoryCfg := buffer.NewMemoryBufferConfig()
@@ -67,6 +68,7 @@ func TestFlushBufferOnClose(t *testing.T) {
 		body, _ := ioutil.ReadAll(req.Body)
 		received <- body
 	}))
+	defer srv.Close()
 
 	cfg.Address = srv.URL
 	ops, err := cfg.Build((testutil.NewBuildContext(t)))

--- a/operator/builtin/output/forward/forward_test.go
+++ b/operator/builtin/output/forward/forward_test.go
@@ -83,4 +83,7 @@ func TestFlushBufferOnClose(t *testing.T) {
 
 	err = forwardOutput.Stop()
 	require.NoError(t, err)
+
+	response := <-received
+	require.Contains(t, string(response), `"body":"test"`)
 }


### PR DESCRIPTION
## Description of Changes
* Entries are now flushed upon the closing of buffer for forward output
* Updated tests to verify forward output does send entries after closing
## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
