### PR TITLE
Re-Add support for shift-jis encoding

### DIFF
--- a/operator/builtin/input/file/config.go
+++ b/operator/builtin/input/file/config.go
@@ -36,7 +36,7 @@ func NewInputConfig(operatorID string) *InputConfig {
 		FingerprintSize:         defaultFingerprintSize,
 		MaxLogSize:              defaultMaxLogSize,
 		MaxConcurrentFiles:      defaultMaxConcurrentFiles,
-		Encoding:                helper.NewEncodingConfig(),
+		Encoding:                szhelper.NewEncodingConfig(),
 		FilenameRecallPeriod:    helper.Duration{Duration: defaultFilenameRecallPeriod},
 	}
 }
@@ -46,20 +46,20 @@ type InputConfig struct {
 	helper.InputConfig `yaml:",inline"`
 	Finder             `mapstructure:",squash" yaml:",inline"`
 
-	PollInterval            helper.Duration          `mapstructure:"poll_interval,omitempty"               json:"poll_interval,omitempty"               yaml:"poll_interval,omitempty"`
-	Multiline               szhelper.MultilineConfig `mapstructure:"multiline,omitempty"                   json:"multiline,omitempty"                   yaml:"multiline,omitempty"`
-	IncludeFileName         bool                     `mapstructure:"include_file_name,omitempty"           json:"include_file_name,omitempty"           yaml:"include_file_name,omitempty"`
-	IncludeFilePath         bool                     `mapstructure:"include_file_path,omitempty"           json:"include_file_path,omitempty"           yaml:"include_file_path,omitempty"`
-	IncludeFileNameResolved bool                     `mapstructure:"include_file_name_resolved,omitempty"  json:"include_file_name_resolved,omitempty"  yaml:"include_file_name_resolved,omitempty"`
-	IncludeFilePathResolved bool                     `mapstructure:"include_file_path_resolved,omitempty"  json:"include_file_path_resolved,omitempty"  yaml:"include_file_path_resolved,omitempty"`
-	StartAt                 string                   `mapstructure:"start_at,omitempty"                    json:"start_at,omitempty"                    yaml:"start_at,omitempty"`
-	FingerprintSize         helper.ByteSize          `mapstructure:"fingerprint_size,omitempty"            json:"fingerprint_size,omitempty"            yaml:"fingerprint_size,omitempty"`
-	MaxLogSize              helper.ByteSize          `mapstructure:"max_log_size,omitempty"                json:"max_log_size,omitempty"                yaml:"max_log_size,omitempty"`
-	MaxConcurrentFiles      int                      `mapstructure:"max_concurrent_files,omitempty"        json:"max_concurrent_files,omitempty"        yaml:"max_concurrent_files,omitempty"`
-	DeleteAfterRead         bool                     `mapstructure:"delete_after_read,omitempty"           json:"delete_after_read,omitempty"           yaml:"delete_after_read,omitempty"`
-	LabelRegex              string                   `mapstructure:"label_regex,omitempty"                 json:"label_regex,omitempty"                 yaml:"label_regex,omitempty"`
-	Encoding                helper.EncodingConfig    `mapstructure:",squash,omitempty"                     json:",inline,omitempty"                     yaml:",inline,omitempty"`
-	FilenameRecallPeriod    helper.Duration          `mapstructure:"filename_recall_period,omitempty"      json:"filename_recall_period,omitempty"      yaml:"filename_recall_period,omitempty"`
+	PollInterval            helper.Duration               `mapstructure:"poll_interval,omitempty"               json:"poll_interval,omitempty"               yaml:"poll_interval,omitempty"`
+	Multiline               szhelper.MultilineConfig      `mapstructure:"multiline,omitempty"                   json:"multiline,omitempty"                   yaml:"multiline,omitempty"`
+	IncludeFileName         bool                          `mapstructure:"include_file_name,omitempty"           json:"include_file_name,omitempty"           yaml:"include_file_name,omitempty"`
+	IncludeFilePath         bool                          `mapstructure:"include_file_path,omitempty"           json:"include_file_path,omitempty"           yaml:"include_file_path,omitempty"`
+	IncludeFileNameResolved bool                          `mapstructure:"include_file_name_resolved,omitempty"  json:"include_file_name_resolved,omitempty"  yaml:"include_file_name_resolved,omitempty"`
+	IncludeFilePathResolved bool                          `mapstructure:"include_file_path_resolved,omitempty"  json:"include_file_path_resolved,omitempty"  yaml:"include_file_path_resolved,omitempty"`
+	StartAt                 string                        `mapstructure:"start_at,omitempty"                    json:"start_at,omitempty"                    yaml:"start_at,omitempty"`
+	FingerprintSize         helper.ByteSize               `mapstructure:"fingerprint_size,omitempty"            json:"fingerprint_size,omitempty"            yaml:"fingerprint_size,omitempty"`
+	MaxLogSize              helper.ByteSize               `mapstructure:"max_log_size,omitempty"                json:"max_log_size,omitempty"                yaml:"max_log_size,omitempty"`
+	MaxConcurrentFiles      int                           `mapstructure:"max_concurrent_files,omitempty"        json:"max_concurrent_files,omitempty"        yaml:"max_concurrent_files,omitempty"`
+	DeleteAfterRead         bool                          `mapstructure:"delete_after_read,omitempty"           json:"delete_after_read,omitempty"           yaml:"delete_after_read,omitempty"`
+	LabelRegex              string                        `mapstructure:"label_regex,omitempty"                 json:"label_regex,omitempty"                 yaml:"label_regex,omitempty"`
+	Encoding                szhelper.StanzaEncodingConfig `mapstructure:",squash,omitempty"                     json:",inline,omitempty"                     yaml:",inline,omitempty"`
+	FilenameRecallPeriod    helper.Duration               `mapstructure:"filename_recall_period,omitempty"      json:"filename_recall_period,omitempty"      yaml:"filename_recall_period,omitempty"`
 }
 
 // Build will build a file input operator from the supplied configuration

--- a/operator/builtin/input/file/config_test.go
+++ b/operator/builtin/input/file/config_test.go
@@ -491,7 +491,9 @@ func TestUnmarshal(t *testing.T) {
 			ExpectErr: false,
 			Expect: func() *InputConfig {
 				cfg := defaultCfg()
-				cfg.Encoding = helper.EncodingConfig{Encoding: "utf-16le"}
+				cfg.Encoding = szhelper.StanzaEncodingConfig{
+					EncodingConfig: helper.EncodingConfig{Encoding: "utf-16le"},
+				}
 				return cfg
 			}(),
 		},
@@ -500,7 +502,9 @@ func TestUnmarshal(t *testing.T) {
 			ExpectErr: false,
 			Expect: func() *InputConfig {
 				cfg := defaultCfg()
-				cfg.Encoding = helper.EncodingConfig{Encoding: "UTF-16lE"}
+				cfg.Encoding = szhelper.StanzaEncodingConfig{
+					EncodingConfig: helper.EncodingConfig{Encoding: "UTF-16lE"},
+				}
 				return cfg
 			}(),
 		},
@@ -603,7 +607,9 @@ func TestBuild(t *testing.T) {
 		{
 			"InvalidEncoding",
 			func(f *InputConfig) {
-				f.Encoding = helper.EncodingConfig{Encoding: "UTF-3233"}
+				f.Encoding = szhelper.StanzaEncodingConfig{
+					EncodingConfig: helper.EncodingConfig{Encoding: "UTF-3233"},
+				}
 			},
 			require.Error,
 			nil,
@@ -726,6 +732,8 @@ func NewTestInputConfig() *InputConfig {
 		LineEndPattern:   "end",
 	}
 	cfg.FingerprintSize = 1024
-	cfg.Encoding = helper.EncodingConfig{Encoding: "utf16"}
+	cfg.Encoding = szhelper.StanzaEncodingConfig{
+		EncodingConfig: helper.EncodingConfig{Encoding: "utf16"},
+	}
 	return cfg
 }

--- a/operator/builtin/input/file/file_test.go
+++ b/operator/builtin/input/file/file_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	szhelper "github.com/observiq/stanza/v2/operator/helper"
 	"github.com/observiq/stanza/v2/operator/helper/persist"
 	"github.com/observiq/stanza/v2/testutil"
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
@@ -982,7 +983,11 @@ func TestEncodings(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			operator, receivedEntries, tempDir := newTestFileOperator(t, func(cfg *InputConfig) {
-				cfg.Encoding = helper.EncodingConfig{Encoding: tc.encoding}
+				cfg.Encoding = szhelper.StanzaEncodingConfig{
+					EncodingConfig: helper.EncodingConfig{
+						Encoding: tc.encoding,
+					},
+				}
 			}, nil)
 
 			// Popualte the file

--- a/operator/helper/encoding.go
+++ b/operator/helper/encoding.go
@@ -1,0 +1,37 @@
+package helper
+
+import (
+	"github.com/open-telemetry/opentelemetry-log-collection/operator"
+	otelhelper "github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/japanese"
+)
+
+var additionalEncodingOverrides = map[string]encoding.Encoding{
+	"shift-jis": japanese.ShiftJIS,
+}
+
+// StanzaEncodingConfig wraps OTel EncodingConfig to add additional encodings
+type StanzaEncodingConfig struct {
+	otelhelper.EncodingConfig `mapstructure:",squash,omitempty" json:",inline,omitempty" yaml:",inline,omitempty"`
+}
+
+// NewBasicConfig creates a new Stanza Encoding config
+func NewEncodingConfig() StanzaEncodingConfig {
+	return StanzaEncodingConfig{
+		EncodingConfig: otelhelper.NewEncodingConfig(),
+	}
+
+}
+
+// Build will build an Encoding operator
+func (s StanzaEncodingConfig) Build(context operator.BuildContext) (otelhelper.Encoding, error) {
+	enc, ok := additionalEncodingOverrides[s.Encoding]
+	if ok {
+		return otelhelper.Encoding{
+			Encoding: enc,
+		}, nil
+	}
+
+	return s.EncodingConfig.Build(context)
+}

--- a/operator/helper/encoding_test.go
+++ b/operator/helper/encoding_test.go
@@ -1,0 +1,69 @@
+package helper
+
+import (
+	"testing"
+
+	"golang.org/x/text/encoding/unicode"
+
+	"github.com/observiq/stanza/v2/testutil"
+	otelhelper "github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/encoding/japanese"
+)
+
+func TestNewEncodingConfig(t *testing.T) {
+	expected := StanzaEncodingConfig{
+		EncodingConfig: otelhelper.NewEncodingConfig(),
+	}
+
+	actual := NewEncodingConfig()
+	require.Equal(t, expected, actual)
+}
+
+func TestStanzaEncoderBuild(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		encoding    string
+		expected    otelhelper.Encoding
+		expectError bool
+	}{
+		{
+			desc:     "shift-jis",
+			encoding: "shift-jis",
+			expected: otelhelper.Encoding{
+				Encoding: japanese.ShiftJIS,
+			},
+			expectError: false,
+		},
+		{
+			desc:     "Supported by otel encoding config",
+			encoding: "utf8",
+			expected: otelhelper.Encoding{
+				Encoding: unicode.UTF8,
+			},
+			expectError: false,
+		},
+		{
+			desc:        "Not supported",
+			encoding:    "bad_stuff",
+			expected:    otelhelper.Encoding{},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ec := NewEncodingConfig()
+			ec.Encoding = tc.encoding
+
+			actual, err := ec.Build(testutil.NewBuildContext(t))
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Description of Changes
Last merge from master reverted support for `shift-jis` encoding as we were importing that file from OTel in v2. Added a wrapper struct to wrap the OTel `EncodingConfig` so we can specify encodings not supported by OTel.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
