### PR TITLE
Correctly parse timestamps from 1970

### DIFF
--- a/operator/helper/time.go
+++ b/operator/helper/time.go
@@ -272,7 +272,7 @@ var subsecToNs = map[string]int64{"s.ms": 1e6, "s.us": 1e3, "s.ns": 1}
 // setTimestampYear sets the year of a timestamp to the current year.
 // This is needed because year is missing from some time formats, such as rfc3164.
 func setTimestampYear(t time.Time) time.Time {
-	if t.Year() > 1970 {
+	if t.Year() > 0 {
 		return t
 	}
 	n := now()

--- a/operator/helper/time_test.go
+++ b/operator/helper/time_test.go
@@ -297,6 +297,13 @@ func TestTimeParser(t *testing.T) {
 			strptimeLayout: "%Y-%m-%dT%H:%M:%S.%LZ",
 			location:       hst.String(),
 		},
+		{
+			name:           "1970",
+			sample:         "1970-12-16T21:43:28.391Z",
+			expected:       time.Date(1970, 12, 16, 21, 43, 28, 391*1000*1000, time.UTC),
+			gotimeLayout:   "2006-01-02T15:04:05.999Z",
+			strptimeLayout: "%Y-%m-%dT%H:%M:%S.%LZ",
+		},
 	}
 
 	rootField := entry.NewRecordField()


### PR DESCRIPTION
## Description of Changes

See OTEL issue https://github.com/open-telemetry/opentelemetry-log-collection/issues/414

Porting this OTEL PR https://github.com/open-telemetry/opentelemetry-log-collection/pull/417

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
