### PR TITLE
doc: Proxy settings should use systemd override

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -10,9 +10,10 @@ export HTTPS_PROXY=http://user:password@myproxy:3128
 stanza -c ./config.yaml
 ```
 
-To set this for the Stanza service on Linux, the service file can be modified with `systemctl edit --full stanza`, and add the following lines in the `[Service]` section.
+To set this for the Stanza service on Linux, the service file can be modified with `systemctl edit stanza`, and add the following lines in the `[Service]` section.
 
 ```service
+[Service]
 Environment=HTTP_PROXY=http://user:password@myproxy:3128
 Environment=HTTPS_PROXY=http://user:password@myproxy:3128
 ```


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

When enabling proxy, we should be using a systemd override instead of editing the main service file. This is because the package manager (rpm / deb) will replace the systemd service. Using an override allows the user to make changes without preventing us from making changes to the main service.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
