### PR TITLE
fix(bug): create /usr/local/bin if not present 

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ Group=root
 
 Restart Stanza: `sudo systemctl restart stanza`.
 
-### Linux / Macos Script
+### Linux / macOS Script
 
 - Single command install, requires the `curl` command
 - Stanza will automatically be running as a service
 - On Linux, Stanza will be running as the `root` user. On Macos, Stanza will be running as your current user.
-- `sudo` may be required if user running installer needs permission to write to installation locations and linking to `/usr/local/bin`.
+- `sudo` is always required for Linux installations while macOS requires it if the invoking user does not have write permissions to `/usr/local/bin`.
 
 ```shell
 sh -c "$(curl -fsSlL https://github.com/observiq/stanza/releases/latest/download/unix-install.sh)" unix-install.sh

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Restart Stanza: `sudo systemctl restart stanza`.
 - Single command install, requires the `curl` command
 - Stanza will automatically be running as a service
 - On Linux, Stanza will be running as the `root` user. On Macos, Stanza will be running as your current user.
+- `sudo` may be required if user running installer needs permission to write to installation locations and linking to `/usr/local/bin`.
 
 ```shell
 sh -c "$(curl -fsSlL https://github.com/observiq/stanza/releases/latest/download/unix-install.sh)" unix-install.sh

--- a/scripts/unix-install.sh
+++ b/scripts/unix-install.sh
@@ -481,8 +481,12 @@ install_package()
 
   info "Setting permissions..."
   chmod +x "$agent_binary"
-  ln -sf "$agent_binary" "/usr/local/bin/$BINARY_NAME"
   succeeded
+
+  info "Linking binary $agent_binary => /usr/local/bin/$BINARY_NAME"
+  mkdir -p /usr/local/bin
+  ln -sf "$agent_binary" "/usr/local/bin/$BINARY_NAME"
+  succeeded  
 
   info "Downloading plugins..."
   mkdir -p "$agent_home/tmp"


### PR DESCRIPTION

<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

- Some installations(notably default M1 macOS 12) do not have the folder `/usr/local/bin` present when they run the installer. So this PR addresses this by ensuring the directory exists before linking the installed binary to the $PATH

Tested on linux by removing the /usr/local/bin and rerunning the installer whereas on `main` it failed. 

From my understanding it is the responsibility of the third party app in the macOS ecosystem to create the folder if it wishes to add things to `/usr/local/bin` https://discussions.apple.com/thread/252495484

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
