### PR TITLE
fix: Set read timeout for forward input operator

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -13,7 +13,6 @@ on:
     #        *  * * * *
     - cron: '30 1 * * *'
   pull_request:
-    branches: [ master ]
 
 jobs:
   tests:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,11 +1,7 @@
 name: license
 on:
   pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
+
 jobs:
   build:
     name: Scan Licenses

--- a/docs/operators/forward_input.md
+++ b/docs/operators/forward_input.md
@@ -9,6 +9,7 @@ The `foward_input` operator receives logs from another Stanza instance running `
 | `id`             | `forward_output` | A unique identifier for the operator                  |
 | `listen_address` | `:80`            | The IP address and port to listen on                  |
 | `tls`            |                  | A block for configuring the server to listen with TLS |
+| `read_timeout`   | `5s`             | Maximum duration for reading the entire request, including the body. |
 
 #### TLS block configuration
 

--- a/operator/builtin/input/forward/forward.go
+++ b/operator/builtin/input/forward/forward.go
@@ -56,6 +56,10 @@ func (c *ForwardInputConfig) Build(context operator.BuildContext) ([]operator.Op
 		Addr:        c.ListenAddress,
 		Handler:     forwardInput,
 		ReadTimeout: c.ReadTimeout.Duration,
+		// ReadHeaderTimeout defaults to ReadTimeout, but Gosec fails
+		// if this value is not set. For simplicity, only ReadTimeout
+		// is exposed to the user.
+		ReadHeaderTimeout: c.ReadTimeout.Duration,
 	}
 
 	return []operator.Operator{forwardInput}, nil

--- a/operator/builtin/input/forward/forward_test.go
+++ b/operator/builtin/input/forward/forward_test.go
@@ -23,6 +23,7 @@ func TestForwardInput(t *testing.T) {
 	cfg := NewForwardInputConfig("test")
 	cfg.ListenAddress = "0.0.0.0:0"
 	cfg.OutputIDs = []string{"fake"}
+	require.Equal(t, time.Second*5, cfg.ReadTimeout.Duration)
 
 	ops, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)

--- a/operator/builtin/input/forward/forward_test.go
+++ b/operator/builtin/input/forward/forward_test.go
@@ -28,6 +28,8 @@ func TestForwardInput(t *testing.T) {
 	ops, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
 	forwardInput := ops[0].(*ForwardInput)
+	require.Equal(t, time.Second*5, forwardInput.srv.ReadTimeout)
+	require.Equal(t, time.Second*5, forwardInput.srv.ReadHeaderTimeout)
 
 	fake := testutil.NewFakeOutput(t)
 	err = forwardInput.SetOutputs([]operator.Operator{fake})


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Added ReadTimeout param to Forward Input Operator. Defaults to 5 seconds and is configurable by the user.

It is a good idea to set this value anyway, and it resolves [Gosec CI cron failure](https://github.com/observIQ/stanza/actions/runs/2518914197).
```
[/github/workspace/operator/builtin/input/forward/forward.go:52-55] - G112 (CWE-400): Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (Confidence: LOW, Severity: MEDIUM)
    51: 
  > 52: 	forwardInput.srv = &http.Server{
  > 53: 		Addr:    c.ListenAddress,
  > 54: 		Handler: forwardInput,
  > 55: 	}
```

Gosec and license workflows were not running on PR, updated them to match the other workflows.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
