### PR TITLE
fix: Update LICENSE to use observIQ in copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright Blue Medora, Inc., The OpenTelemetry Authors
+   Copyright observIQ, Inc., The OpenTelemetry Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description of Changes
Updates the LICENSE file to use observIQ in the copyright vs Blue Medora

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
